### PR TITLE
Add OIDC Provider support for OpenTDF integration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,15 @@ export DYNAMODB_DEVICE_BINDINGS_TABLE=device_bindings
 # Optional: Set port (defaults to 8080)
 export PORT=8080
 
+# Optional: OIDC provider configuration (required to act as an OIDC IdP)
+export OIDC_ISSUER=https://identity.arkavo.net
+export OIDC_CLIENT_ID=opentdf
+export OIDC_CLIENT_SECRET=<shared-secret-or-omit-for-public-PKCE-clients>
+export OIDC_REDIRECT_URIS=https://opentdf.example/callback,https://opentdf.example/oauth/cb
+
+# Optional: Sign in with Apple
+export APPLE_CLIENT_ID=com.arkavo.app
+
 # Run the server
 cargo run
 ```
@@ -157,6 +166,34 @@ aws dynamodb create-table \
 - Graceful handling of missing handles table during user creation
 - Device binding CRUD operations for App Attest
 
+**oidc.rs** - OpenID Connect (OIDC) Provider endpoints
+- `/.well-known/openid-configuration`: Discovery document
+- `/.well-known/jwks.json`: JWKS (advertises the EC P-256 signing key as a JWK)
+- `/oauth/authorize`: Authorization endpoint (code flow with PKCE)
+- `/oauth/token`: Token endpoint (issues ID + access tokens, ES256-signed)
+- `/oauth/userinfo`: UserInfo endpoint
+- Issues OpenTDF-compatible claims: `iss`, `sub` (e.g. `apple:APPLE_SUB` or
+  `arkavo:UUID`), `aud`, `email`, `email_verified`, `idp`,
+  `arkavo_account_id`, `arkavo_roles`, `arkavo_entitlements`
+- Authorization codes stored in an in-memory `AuthorizationCodeStore` (10-min
+  lifetime, single-use). For multi-instance deployments swap for a shared store.
+- Confidential clients use `client_secret`; public clients must use PKCE (S256).
+- Upstream authentication: WebAuthn-issued Arkavo JWT (via `X-Auth-Token`) or
+  Apple id_token (via `idp=apple` + `id_token` query/`X-Apple-Id-Token` header).
+
+**apple_signin.rs** - Sign in with Apple integration
+- Validates Apple-issued id_tokens against Apple's JWKS (cached for 1h)
+- `POST /oauth/apple/idtoken`: Native flow — iOS app posts id_token, server
+  returns the Arkavo identity record
+- `POST /oauth/apple/callback`: Web-flow callback (form_post). Code-exchange
+  against Apple's token endpoint is left as a follow-up; today the callback
+  requires `response_mode=form_post` + `scope=name email` so Apple includes
+  `id_token` directly in the form post.
+- Maps Apple `sub` → Arkavo account (`apple-<sub>` username, synthetic
+  `did:key:apple-<sha256(sub)>` DID)
+- Requires `APPLE_CLIENT_ID` to be set (the Apple Service ID / bundle ID
+  configured in the Apple Developer console)
+
 **device_check.rs** - Apple DeviceCheck/App Attest integration
 - `generate_challenge`: Issues random challenge for attestation/assertion
 - `finish_attestation`: Validates attestation object, stores device binding
@@ -194,6 +231,18 @@ aws dynamodb create-table \
    - Validates client (arkavo, arkavocreator) and provider parameters
    - Sanitizes OAuth codes and error messages to prevent injection
    - Redirects to app-specific deep links (e.g., `arkavo://oauth/patreon?code=...`)
+
+5. **OIDC Provider Flow (for OpenTDF and other RPs)**:
+   - Relying party (RP) redirects user-agent to `/oauth/authorize?response_type=code&client_id=...&redirect_uri=...&scope=openid&state=...&nonce=...`
+   - User-agent must already be authenticated via an upstream source:
+     - WebAuthn: present a valid Arkavo JWT via `X-Auth-Token` header
+     - Apple: pass `idp=apple` + Apple `id_token` (validated against Apple JWKS)
+   - Server resolves/provisions the Arkavo account, mints a single-use
+     authorization code, redirects back to `redirect_uri` with `code` + `state`
+   - RP exchanges code at `/oauth/token` (HTTP Basic or form auth; PKCE for
+     public clients). Server returns `access_token` + `id_token` (both ES256,
+     1h lifetime) with OpenTDF-compatible claims
+   - RP can call `/oauth/userinfo` with `Authorization: Bearer <access_token>`
 
 4. **Apple DeviceCheck/App Attest Flow**:
    - **One-time Attestation**:
@@ -269,6 +318,10 @@ The codebase uses thiserror for structured error handling:
   - `authn.rs`: DID validation, handle validation, token expiration, error responses (5 tests)
   - `db.rs`: DID format, error conversions, JSON serialization, error messages (8 tests)
   - `device_check.rs`: Challenge generation, authenticator data parsing, counter validation, error responses (6 tests)
+  - `oidc.rs`: JWK serialization/thumbprint, PKCE S256 verifier, authorization code
+    store lifecycle, discovery/JWKS endpoint shape, claim serialization (10 tests)
+  - `apple_signin.rs`: id_token claim deserialization, error status mapping,
+    username sanitization, hash stability (6 tests)
 - Integration test skeleton in tests/integration_test.rs
 - Test app routing with tower::ServiceExt::oneshot for request simulation
 - Mock requests use axum::body::Body::empty()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,8 +48,9 @@ export OIDC_CLIENT_ID=opentdf
 export OIDC_CLIENT_SECRET=<shared-secret-or-omit-for-public-PKCE-clients>
 export OIDC_REDIRECT_URIS=https://opentdf.example/callback,https://opentdf.example/oauth/cb
 
-# Optional: Sign in with Apple
-export APPLE_CLIENT_ID=com.arkavo.app
+# Optional: Sign in with Apple. Accepts a comma-separated list so the same
+# AuthNZ instance can serve an iOS bundle id + web Service ID.
+export APPLE_CLIENT_ID=com.arkavo.app,com.arkavo.web
 
 # Run the server
 cargo run
@@ -182,17 +183,30 @@ aws dynamodb create-table \
   Apple id_token (via `idp=apple` + `id_token` query/`X-Apple-Id-Token` header).
 
 **apple_signin.rs** - Sign in with Apple integration
-- Validates Apple-issued id_tokens against Apple's JWKS (cached for 1h)
-- `POST /oauth/apple/idtoken`: Native flow — iOS app posts id_token, server
-  returns the Arkavo identity record
-- `POST /oauth/apple/callback`: Web-flow callback (form_post). Code-exchange
-  against Apple's token endpoint is left as a follow-up; today the callback
-  requires `response_mode=form_post` + `scope=name email` so Apple includes
-  `id_token` directly in the form post.
-- Maps Apple `sub` → Arkavo account (`apple-<sub>` username, synthetic
-  `did:key:apple-<sha256(sub)>` DID)
-- Requires `APPLE_CLIENT_ID` to be set (the Apple Service ID / bundle ID
-  configured in the Apple Developer console)
+- Validates Apple-issued id_tokens against Apple's JWKS (cached 1h with
+  force-refresh on `kid` miss in case Apple rotated keys)
+- Every accepted id_token must clear:
+  - **Signature** vs Apple JWKS
+  - **`iss`** = `https://appleid.apple.com`
+  - **`aud`** ∈ comma-separated `APPLE_CLIENT_ID` list (iOS bundle + web
+    Service ID can coexist on the same deployment)
+  - **`nonce`** must match the server-issued nonce (verbatim or hex SHA-256;
+    constant-time compare). No nonce ⇒ refuse.
+  - **`exp`/`iat`** via `jsonwebtoken::Validation`
+- `GET /oauth/apple/nonce`: issues a 256-bit server nonce, persists in session
+- `POST /oauth/apple/idtoken`: Native flow — client must have called
+  `/oauth/apple/nonce` first; server consumes session nonce (single-use) and
+  validates the id_token against it
+- `POST /oauth/apple/callback`: **explicitly disabled** (HTTP 501). Apple web
+  callback requires both code-exchange (signed client-secret JWT against
+  Apple's token endpoint) *and* state-bound nonce verification. Until both
+  are implemented this endpoint always rejects, so misconfigured Apple
+  Service IDs fail loudly rather than being silently accepted.
+- `map_apple_user` persists `apple:<sub> → arkavo_account_id` in DynamoDB
+  (credentials table, keyed by `apple-<sanitized_sub>` username). Apple `sub`
+  is the canonical join key — email is optional metadata and never used to
+  locate accounts (private-relay rotation safe).
+- Requires `APPLE_CLIENT_ID` to be set (one or more comma-separated values).
 
 **device_check.rs** - Apple DeviceCheck/App Attest integration
 - `generate_challenge`: Issues random challenge for attestation/assertion
@@ -236,7 +250,11 @@ aws dynamodb create-table \
    - Relying party (RP) redirects user-agent to `/oauth/authorize?response_type=code&client_id=...&redirect_uri=...&scope=openid&state=...&nonce=...`
    - User-agent must already be authenticated via an upstream source:
      - WebAuthn: present a valid Arkavo JWT via `X-Auth-Token` header
-     - Apple: pass `idp=apple` + Apple `id_token` (validated against Apple JWKS)
+     - Apple: pass `idp=apple` + Apple `id_token` (validated against Apple
+       JWKS). The OIDC `nonce` query parameter is **required** for
+       `idp=apple` and doubles as the Apple nonce — the client must use the
+       same value when invoking Apple Sign In so the id_token's `nonce`
+       claim matches (verbatim or hex SHA-256).
    - Server resolves/provisions the Arkavo account, mints a single-use
      authorization code, redirects back to `redirect_uri` with `code` + `state`
    - RP exchanges code at `/oauth/token` (HTTP Basic or form auth; PKCE for

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ http = "1.3"
 aws-config = "1.8"
 aws-sdk-dynamodb = "1.98"
 bytes = "1.9"
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+url = "2.5"
 # Security-critical dependencies - versions locked for audit trail
 ciborium = "=0.2.2"      # CBOR parsing for attestation objects
 x509-parser = "=0.16.0"  # Certificate chain validation

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "authnz-rs"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 license = "BSD-2"
 rust-version = "1.91.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ p256 = { version = "0.13", features = ["ecdsa", "pkcs8"] }
 ecdsa = { version = "0.16", features = ["signing", "std", "verifying"] }
 sha2 = "0.10"
 uuid = { version = "1.18", features = ["v4"] }
-jsonwebtoken = { version = "9.3", features = ["use_pem"] }
+jsonwebtoken = { version = "10.3.0", features = ["rust_crypto"] }
 chrono = "0.4"
 form_urlencoded = "1.2"
 http = "1.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ codegen-units = 16  # Increase parallelism
 [dependencies]
 tokio = { version = "1.47", features = ["rt", "rt-multi-thread", "macros", "fs", "net", "io-util"] }
 axum = { version = "0.7", features = ["http2", "tokio"] }
+fred = { version = "9.0" }
 tokio-rustls = "0.26"
 rustls = "0.23"
 rustls-pemfile = "2.2"

--- a/README.md
+++ b/README.md
@@ -188,10 +188,67 @@ cargo clippy
 7. Monitor and log authentication attempts
 8. Regularly update dependencies
 
+## OIDC Provider
+
+This service can act as an OpenID Connect identity provider for OpenTDF and
+other relying parties.
+
+| Endpoint                              | Purpose                                  |
+| ------------------------------------- | ---------------------------------------- |
+| `GET /.well-known/openid-configuration` | OIDC discovery document                |
+| `GET /.well-known/jwks.json`            | Public ES256 signing key as a JWK      |
+| `GET /oauth/authorize`                  | Authorization endpoint (code flow)     |
+| `POST /oauth/token`                     | Token endpoint                         |
+| `GET /oauth/userinfo`                   | UserInfo endpoint                      |
+| `POST /oauth/apple/idtoken`             | Native Sign in with Apple (id_token)   |
+| `POST /oauth/apple/callback`            | Web-flow Sign in with Apple callback   |
+
+Token claims issued for OpenTDF compatibility:
+
+```json
+{
+  "iss": "https://identity.arkavo.net",
+  "sub": "apple:APPLE_SUB",
+  "aud": "opentdf",
+  "email": "user@privaterelay.appleid.com",
+  "email_verified": true,
+  "idp": "apple",
+  "arkavo_account_id": "uuid",
+  "arkavo_roles": ["user"],
+  "arkavo_entitlements": ["tdf:create", "tdf:decrypt"]
+}
+```
+
+Configure OpenTDF to trust this issuer:
+
+```
+issuer = https://identity.arkavo.net
+jwks_uri = https://identity.arkavo.net/.well-known/jwks.json
+username_claim = sub
+group_claim = arkavo_roles
+```
+
+### Required configuration
+
+```env
+export OIDC_ISSUER=https://identity.arkavo.net          # default
+export OIDC_CLIENT_ID=opentdf
+export OIDC_CLIENT_SECRET=...                           # optional; public clients use PKCE
+export OIDC_REDIRECT_URIS=https://opentdf.example/cb,https://opentdf.example/oauth/cb
+export APPLE_CLIENT_ID=com.arkavo.app                   # only needed for Sign in with Apple
+```
+
 ## Future Improvements
 
-- Implement key rotation
-- Add an endpoint to retrieve public keys
+- Implement key rotation (JWKS currently exposes a single static key derived
+  from `DECODING_KEY_PATH`; rotation requires multi-key issuance with overlap)
+- Apple OAuth code-exchange flow (client-secret JWT signed with Apple
+  developer private key)
+- Persist OIDC roles/entitlements per Arkavo account (today defaults are baked
+  into the upstream-auth resolution)
+- Replace in-memory OIDC `AuthorizationCodeStore` with a shared store
+  (DynamoDB/Redis) for multi-instance deployments
+- Refresh tokens / `offline_access` scope
 - Implement signature verification on the client-side
 - Enhance error handling and logging for key operations
 - Consider using a key management service for production environments

--- a/README.md
+++ b/README.md
@@ -193,15 +193,48 @@ cargo clippy
 This service can act as an OpenID Connect identity provider for OpenTDF and
 other relying parties.
 
-| Endpoint                              | Purpose                                  |
-| ------------------------------------- | ---------------------------------------- |
-| `GET /.well-known/openid-configuration` | OIDC discovery document                |
-| `GET /.well-known/jwks.json`            | Public ES256 signing key as a JWK      |
-| `GET /oauth/authorize`                  | Authorization endpoint (code flow)     |
-| `POST /oauth/token`                     | Token endpoint                         |
-| `GET /oauth/userinfo`                   | UserInfo endpoint                      |
-| `POST /oauth/apple/idtoken`             | Native Sign in with Apple (id_token)   |
-| `POST /oauth/apple/callback`            | Web-flow Sign in with Apple callback   |
+| Endpoint                              | Purpose                                       |
+| ------------------------------------- | --------------------------------------------- |
+| `GET /.well-known/openid-configuration` | OIDC discovery document                     |
+| `GET /.well-known/jwks.json`            | Public ES256 signing key as a JWK           |
+| `GET /oauth/authorize`                  | Authorization endpoint (code flow)          |
+| `POST /oauth/token`                     | Token endpoint                              |
+| `GET /oauth/userinfo`                   | UserInfo endpoint                           |
+| `GET /oauth/apple/nonce`                | Issue server-side nonce for Apple native flow |
+| `POST /oauth/apple/idtoken`             | Native Sign in with Apple (id_token + nonce)|
+| `POST /oauth/apple/callback`            | Web-flow Apple callback — **disabled (501)** until full code-exchange + state-bound nonce land |
+
+### Apple Sign In security gates
+
+Every accepted Apple id_token must clear all of:
+
+1. **Signature** against Apple's JWKS (`https://appleid.apple.com/auth/keys`),
+   cached for 1 hour with force-refresh on `kid` miss.
+2. **Issuer**: `iss == https://appleid.apple.com`.
+3. **Audience**: `aud` must equal one of the configured `APPLE_CLIENT_ID`
+   values. `APPLE_CLIENT_ID` accepts a comma-separated list so an iOS bundle
+   id and a web Service ID can coexist on the same deployment.
+4. **Nonce**: a server-issued nonce is **required**. For the native flow the
+   client must first call `GET /oauth/apple/nonce` (session-bound, single-use,
+   10-minute TTL). For `GET /oauth/authorize?idp=apple` the OIDC `nonce`
+   query parameter is reused as the Apple nonce. In both cases the id_token's
+   `nonce` claim must match the raw nonce verbatim *or* its hex SHA-256 (per
+   Apple's recommended client-side hashing pattern). Comparison is
+   constant-time.
+5. **`exp`/`iat`** via `jsonwebtoken::Validation`.
+
+The web callback (`POST /oauth/apple/callback`) is intentionally rejected
+with HTTP 501 until full code-exchange (signed client-secret JWT against
+Apple's `/auth/token`) and state-bound nonce verification are implemented.
+This is a deliberate "fail loudly" choice: a misconfigured Apple Service ID
+that posts a code-only callback returns a clear error instead of being
+silently accepted.
+
+Identity mapping is persistent: `map_apple_user` writes an `apple-<sub>` row
+to the DynamoDB credentials table on first login, and every subsequent login
+re-fetches the row. The Apple `sub` is the canonical account key; email is
+treated as optional metadata so private-relay address rotation does not
+break identity continuity.
 
 Token claims issued for OpenTDF compatibility:
 
@@ -235,7 +268,7 @@ export OIDC_ISSUER=https://identity.arkavo.net          # default
 export OIDC_CLIENT_ID=opentdf
 export OIDC_CLIENT_SECRET=...                           # optional; public clients use PKCE
 export OIDC_REDIRECT_URIS=https://opentdf.example/cb,https://opentdf.example/oauth/cb
-export APPLE_CLIENT_ID=com.arkavo.app                   # only needed for Sign in with Apple
+export APPLE_CLIENT_ID=com.arkavo.app,com.arkavo.web    # comma-separated; iOS bundle + web Service ID
 ```
 
 ## Future Improvements

--- a/src/apple_signin.rs
+++ b/src/apple_signin.rs
@@ -1,0 +1,517 @@
+//! Sign in with Apple integration.
+//!
+//! Apple is treated as an *upstream* identity provider: end-users sign in with
+//! their Apple ID, and Arkavo AuthNZ trusts Apple's id_token only after
+//! validating its signature against Apple's published JWKS. The resulting
+//! Apple claims are mapped onto an Arkavo account before any OIDC tokens are
+//! issued downstream. This ensures OpenTDF and other relying parties never
+//! trust Apple directly — they trust AuthNZ, and AuthNZ decides which upstream
+//! sources are acceptable.
+//!
+//! Supported flows:
+//!
+//! - Native flow (`/oauth/apple/idtoken`): the iOS app uses
+//!   `ASAuthorizationAppleIDProvider` to obtain an id_token, then POSTs it to
+//!   this server. We validate the signature, map to an Arkavo account, and
+//!   return an Arkavo JWT (or, when called from `/oauth/authorize`, an OIDC
+//!   authorization code).
+//! - Web flow (`/oauth/apple/callback`): scaffolded for completeness. Apple's
+//!   web flow requires a client secret JWT signed by the operator's Apple
+//!   private key. Operators must set `APPLE_TEAM_ID`, `APPLE_KEY_ID`,
+//!   `APPLE_PRIVATE_KEY_PATH`, `APPLE_CLIENT_ID`, and `APPLE_REDIRECT_URI`.
+//!   The code-exchange step against Apple is intentionally left as a TODO in
+//!   the initial OIDC provider PR.
+
+use crate::AppState;
+use crate::constants::{APPLE_ISSUER, APPLE_JWKS_CACHE_TTL_SECONDS, APPLE_JWKS_URL};
+use crate::db::DynamoDBError;
+use crate::oidc::AuthenticatedUser;
+use axum::Json;
+use axum::extract::Extension;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use chrono::Utc;
+use jsonwebtoken::jwk::{AlgorithmParameters, Jwk};
+use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode, decode_header};
+use log::{debug, error, info, warn};
+use serde::{Deserialize, Serialize};
+use std::env;
+use std::sync::Arc;
+use thiserror::Error;
+use tokio::sync::RwLock;
+
+/// Claims published by Apple in id_tokens.
+///
+/// Apple only includes `email` on the *first* successful authentication
+/// for a given user/app pair, so callers must persist the mapping locally.
+#[derive(Debug, Clone, Deserialize)]
+#[allow(dead_code)]
+pub struct AppleIdTokenClaims {
+    pub iss: String,
+    pub sub: String,
+    pub aud: String,
+    pub iat: i64,
+    pub exp: i64,
+    pub nonce: Option<String>,
+    pub email: Option<String>,
+    pub email_verified: Option<EmailVerified>,
+    pub is_private_email: Option<EmailVerified>,
+}
+
+/// Apple sends `email_verified`/`is_private_email` as either a JSON bool or
+/// a JSON string ("true"/"false"). Handle both.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum EmailVerified {
+    Bool(bool),
+    Str(String),
+}
+
+impl EmailVerified {
+    pub fn as_bool(&self) -> bool {
+        match self {
+            EmailVerified::Bool(b) => *b,
+            EmailVerified::Str(s) => s == "true",
+        }
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum AppleSigninError {
+    #[error("Apple JWKS fetch failed: {0}")]
+    JwksFetch(String),
+    #[error("Apple JWKS parsing failed: {0}")]
+    JwksParse(String),
+    #[error("Apple id_token header missing kid")]
+    MissingKid,
+    #[error("Apple id_token signed by unknown kid: {0}")]
+    UnknownKid(String),
+    #[error("Apple id_token signature/claims invalid: {0}")]
+    InvalidToken(String),
+    #[error("Apple id_token audience mismatch: expected {expected}, got {actual}")]
+    AudienceMismatch { expected: String, actual: String },
+    #[error("APPLE_CLIENT_ID is not configured")]
+    MissingClientId,
+}
+
+impl IntoResponse for AppleSigninError {
+    fn into_response(self) -> Response {
+        let status = match &self {
+            AppleSigninError::JwksFetch(_) | AppleSigninError::JwksParse(_) => {
+                StatusCode::BAD_GATEWAY
+            }
+            AppleSigninError::MissingClientId => StatusCode::INTERNAL_SERVER_ERROR,
+            _ => StatusCode::UNAUTHORIZED,
+        };
+        (status, self.to_string()).into_response()
+    }
+}
+
+/// Cached Apple JWKS. Refreshes lazily on cache miss / expiry.
+pub struct AppleJwksCache {
+    inner: RwLock<CacheState>,
+    client_id: Option<String>,
+}
+
+struct CacheState {
+    keys: Vec<Jwk>,
+    fetched_at: i64,
+}
+
+impl AppleJwksCache {
+    pub fn new() -> Self {
+        Self {
+            inner: RwLock::new(CacheState {
+                keys: Vec::new(),
+                fetched_at: 0,
+            }),
+            client_id: env::var("APPLE_CLIENT_ID").ok(),
+        }
+    }
+
+    pub fn client_id(&self) -> Option<&str> {
+        self.client_id.as_deref()
+    }
+
+    async fn get_keys(&self) -> Result<Vec<Jwk>, AppleSigninError> {
+        let now = Utc::now().timestamp();
+        {
+            let state = self.inner.read().await;
+            if !state.keys.is_empty() && now - state.fetched_at < APPLE_JWKS_CACHE_TTL_SECONDS {
+                return Ok(state.keys.clone());
+            }
+        }
+
+        let response = reqwest::get(APPLE_JWKS_URL)
+            .await
+            .map_err(|e| AppleSigninError::JwksFetch(e.to_string()))?;
+        if !response.status().is_success() {
+            return Err(AppleSigninError::JwksFetch(format!(
+                "HTTP {}",
+                response.status()
+            )));
+        }
+        let body: AppleJwksResponse = response
+            .json()
+            .await
+            .map_err(|e| AppleSigninError::JwksParse(e.to_string()))?;
+
+        let mut state = self.inner.write().await;
+        state.keys = body.keys;
+        state.fetched_at = now;
+        Ok(state.keys.clone())
+    }
+
+    async fn invalidate(&self) {
+        let mut state = self.inner.write().await;
+        state.fetched_at = 0;
+        state.keys.clear();
+    }
+}
+
+impl Default for AppleJwksCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct AppleJwksResponse {
+    keys: Vec<Jwk>,
+}
+
+/// Verify an Apple-issued id_token. Returns the verified claims on success.
+pub async fn verify_apple_id_token(
+    cache: &AppleJwksCache,
+    id_token: &str,
+) -> Result<AppleIdTokenClaims, AppleSigninError> {
+    let client_id = cache
+        .client_id()
+        .ok_or(AppleSigninError::MissingClientId)?
+        .to_string();
+
+    let header = decode_header(id_token)
+        .map_err(|e| AppleSigninError::InvalidToken(format!("header decode: {}", e)))?;
+    let kid = header.kid.ok_or(AppleSigninError::MissingKid)?;
+
+    let keys = cache.get_keys().await?;
+    if let Some(jwk) = find_jwk(&keys, &kid) {
+        return verify_apple_id_token_with_jwk(jwk, id_token, &client_id);
+    }
+
+    // Cache miss: force a refresh in case Apple rotated keys.
+    warn!("Apple kid {} not in cache; forcing JWKS refresh", kid);
+    cache.invalidate().await;
+    let keys = cache.get_keys().await?;
+    let jwk = find_jwk(&keys, &kid).ok_or_else(|| AppleSigninError::UnknownKid(kid.clone()))?;
+    verify_apple_id_token_with_jwk(jwk, id_token, &client_id)
+}
+
+fn find_jwk<'a>(keys: &'a [Jwk], kid: &str) -> Option<&'a Jwk> {
+    keys.iter().find(|k| {
+        k.common
+            .key_id
+            .as_deref()
+            .map(|k_id| k_id == kid)
+            .unwrap_or(false)
+    })
+}
+
+fn verify_apple_id_token_with_jwk(
+    jwk: &Jwk,
+    id_token: &str,
+    client_id: &str,
+) -> Result<AppleIdTokenClaims, AppleSigninError> {
+    let alg = match &jwk.algorithm {
+        AlgorithmParameters::RSA(_) => Algorithm::RS256,
+        AlgorithmParameters::EllipticCurve(_) => Algorithm::ES256,
+        _ => {
+            return Err(AppleSigninError::InvalidToken(
+                "unsupported JWK algorithm parameters".into(),
+            ));
+        }
+    };
+
+    let decoding_key = DecodingKey::from_jwk(jwk)
+        .map_err(|e| AppleSigninError::InvalidToken(format!("DecodingKey: {}", e)))?;
+
+    let mut validation = Validation::new(alg);
+    validation.set_issuer(&[APPLE_ISSUER]);
+    validation.set_audience(&[client_id]);
+
+    let data = decode::<AppleIdTokenClaims>(id_token, &decoding_key, &validation)
+        .map_err(|e| AppleSigninError::InvalidToken(e.to_string()))?;
+    let claims = data.claims;
+
+    if claims.aud != client_id {
+        return Err(AppleSigninError::AudienceMismatch {
+            expected: client_id.to_string(),
+            actual: claims.aud,
+        });
+    }
+    if claims.iss != APPLE_ISSUER {
+        return Err(AppleSigninError::InvalidToken(format!(
+            "iss mismatch: {}",
+            claims.iss
+        )));
+    }
+
+    Ok(claims)
+}
+
+/// Map verified Apple claims onto an Arkavo account, creating one if needed.
+///
+/// The mapping uses Apple's stable `sub` claim as the join key. For the first
+/// PR we mint a synthetic DID (`did:key:apple-<sub-hash>`) so the existing
+/// DynamoDB `create_user` path (which requires a `did:key:` DID) keeps working.
+/// A follow-up PR can replace this with a richer Apple-account record.
+pub async fn map_apple_user(
+    app_state: &AppState,
+    claims: &AppleIdTokenClaims,
+) -> Result<AuthenticatedUser, DynamoDBError> {
+    // Use the Apple sub as a deterministic username so we can locate the user
+    // on subsequent logins. The leading `apple-` prefix avoids collisions with
+    // WebAuthn-registered usernames.
+    let username = format!("apple-{}", sanitize_for_username(&claims.sub));
+    let did = format!(
+        "did:key:apple-{}",
+        // Truncate to keep DID a sensible length; collisions on the truncated
+        // hash are not relevant because lookups go through `username`.
+        &sha256_hex(&claims.sub)[..32]
+    );
+
+    let user = match app_state.db_store.get_user_by_name(&username).await? {
+        Some(existing) => existing,
+        None => {
+            info!("Provisioning Arkavo account for Apple sub {}", claims.sub);
+            app_state.db_store.create_user(&username, &did).await?
+        }
+    };
+
+    let email_verified = claims.email_verified.as_ref().map(|v| v.as_bool());
+
+    Ok(AuthenticatedUser {
+        subject: format!("apple:{}", claims.sub),
+        arkavo_account_id: user.user_id.to_string(),
+        email: claims.email.clone(),
+        email_verified,
+        idp: "apple".to_string(),
+        roles: vec!["user".to_string()],
+        entitlements: vec!["tdf:create".to_string(), "tdf:decrypt".to_string()],
+    })
+}
+
+fn sanitize_for_username(s: &str) -> String {
+    s.chars()
+        .filter(|c| c.is_alphanumeric() || *c == '-' || *c == '_' || *c == '.')
+        .take(128)
+        .collect()
+}
+
+fn sha256_hex(s: &str) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(s.as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+// --------- HTTP handlers ---------
+
+#[derive(Debug, Deserialize)]
+pub struct AppleIdTokenRequest {
+    pub id_token: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct AppleIdTokenResponse {
+    pub arkavo_account_id: String,
+    pub subject: String,
+    pub idp: String,
+    pub email: Option<String>,
+    pub email_verified: Option<bool>,
+}
+
+/// Native flow: exchange an Apple-issued id_token for an Arkavo identity record.
+///
+/// This endpoint is primarily intended for native iOS clients that have
+/// already completed the Sign in with Apple ceremony on-device. The response
+/// is informational; to obtain OIDC tokens for downstream relying parties,
+/// the client should call `/oauth/authorize` with `idp=apple` and the same
+/// id_token in either the `id_token` query param or the `X-Apple-Id-Token`
+/// header.
+pub async fn apple_idtoken_handler(
+    Extension(app_state): Extension<AppState>,
+    Extension(cache): Extension<Arc<AppleJwksCache>>,
+    Json(req): Json<AppleIdTokenRequest>,
+) -> Response {
+    let claims = match verify_apple_id_token(&cache, &req.id_token).await {
+        Ok(c) => c,
+        Err(e) => return e.into_response(),
+    };
+
+    let user = match map_apple_user(&app_state, &claims).await {
+        Ok(u) => u,
+        Err(e) => {
+            error!("Failed to map Apple user: {}", e);
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to provision Arkavo account: {}", e),
+            )
+                .into_response();
+        }
+    };
+
+    Json(AppleIdTokenResponse {
+        arkavo_account_id: user.arkavo_account_id,
+        subject: user.subject,
+        idp: user.idp,
+        email: user.email,
+        email_verified: user.email_verified,
+    })
+    .into_response()
+}
+
+#[derive(Debug, Deserialize)]
+#[allow(dead_code)]
+pub struct AppleCallbackForm {
+    pub code: Option<String>,
+    pub id_token: Option<String>,
+    pub state: Option<String>,
+    pub error: Option<String>,
+}
+
+/// Web flow callback. Apple POSTs (`response_mode=form_post`) the code and
+/// id_token to this endpoint after the user authenticates on appleid.apple.com.
+///
+/// For now we only support the path where Apple includes the id_token directly
+/// (which it does when `response_mode=form_post` + `scope=name email` are set).
+/// Exchanging `code` for tokens against Apple's `/auth/token` endpoint
+/// requires signing a client secret JWT with the operator's Apple private key
+/// — left as a follow-up.
+pub async fn apple_callback_handler(
+    Extension(app_state): Extension<AppState>,
+    Extension(cache): Extension<Arc<AppleJwksCache>>,
+    Json(form): Json<AppleCallbackForm>,
+) -> Response {
+    if let Some(err) = form.error {
+        return (StatusCode::BAD_REQUEST, format!("apple_error: {}", err)).into_response();
+    }
+    let id_token = match form.id_token {
+        Some(t) => t,
+        None => {
+            debug!(
+                "Apple callback received code but no id_token; code exchange not yet implemented"
+            );
+            return (
+                StatusCode::NOT_IMPLEMENTED,
+                "Apple callback requires id_token in form post. \
+                 Apple code-exchange flow is not yet implemented; configure your \
+                 Apple Service ID with response_mode=form_post and scope=name+email \
+                 so id_token is delivered directly.",
+            )
+                .into_response();
+        }
+    };
+
+    let claims = match verify_apple_id_token(&cache, &id_token).await {
+        Ok(c) => c,
+        Err(e) => return e.into_response(),
+    };
+    let user = match map_apple_user(&app_state, &claims).await {
+        Ok(u) => u,
+        Err(e) => {
+            error!("Failed to map Apple user: {}", e);
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to provision Arkavo account: {}", e),
+            )
+                .into_response();
+        }
+    };
+
+    Json(AppleIdTokenResponse {
+        arkavo_account_id: user.arkavo_account_id,
+        subject: user.subject,
+        idp: user.idp,
+        email: user.email,
+        email_verified: user.email_verified,
+    })
+    .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_email_verified_bool() {
+        let v: EmailVerified = serde_json::from_str("true").unwrap();
+        assert!(v.as_bool());
+        let v: EmailVerified = serde_json::from_str("\"true\"").unwrap();
+        assert!(v.as_bool());
+        let v: EmailVerified = serde_json::from_str("\"false\"").unwrap();
+        assert!(!v.as_bool());
+        let v: EmailVerified = serde_json::from_str("false").unwrap();
+        assert!(!v.as_bool());
+    }
+
+    #[test]
+    fn test_sanitize_for_username() {
+        assert_eq!(
+            sanitize_for_username("000123.abc-def_ghi"),
+            "000123.abc-def_ghi"
+        );
+        assert_eq!(sanitize_for_username("apple/sub<script>"), "applesubscript");
+        let long = "a".repeat(200);
+        assert_eq!(sanitize_for_username(&long).len(), 128);
+    }
+
+    #[test]
+    fn test_sha256_hex_stable() {
+        let a = sha256_hex("apple-sub");
+        let b = sha256_hex("apple-sub");
+        assert_eq!(a, b);
+        assert_eq!(a.len(), 64);
+    }
+
+    #[test]
+    fn test_apple_issuer_constant() {
+        assert_eq!(APPLE_ISSUER, "https://appleid.apple.com");
+    }
+
+    #[test]
+    fn test_apple_signin_error_status_mapping() {
+        assert_eq!(
+            AppleSigninError::JwksFetch("x".into())
+                .into_response()
+                .status(),
+            StatusCode::BAD_GATEWAY
+        );
+        assert_eq!(
+            AppleSigninError::MissingKid.into_response().status(),
+            StatusCode::UNAUTHORIZED
+        );
+        assert_eq!(
+            AppleSigninError::MissingClientId.into_response().status(),
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
+    }
+
+    #[test]
+    fn test_id_token_claims_deserializes_real_shape() {
+        let json = r#"{
+            "iss":"https://appleid.apple.com",
+            "sub":"000123.abc",
+            "aud":"com.arkavo.app",
+            "iat":1700000000,
+            "exp":1700003600,
+            "email":"user@privaterelay.appleid.com",
+            "email_verified":"true",
+            "is_private_email":true
+        }"#;
+        let claims: AppleIdTokenClaims = serde_json::from_str(json).unwrap();
+        assert_eq!(claims.sub, "000123.abc");
+        assert!(claims.email_verified.unwrap().as_bool());
+        assert!(claims.is_private_email.unwrap().as_bool());
+    }
+}

--- a/src/apple_signin.rs
+++ b/src/apple_signin.rs
@@ -603,6 +603,29 @@ pub async fn apple_callback_handler(Json(_form): Json<AppleCallbackForm>) -> Res
         .into_response()
 }
 
+// Allow the binary crate's `Serialize` derive on `AppleNonceResponse` to be
+// reconstructed by tests via `serde_json::from_slice`. (`AppleNonceResponse`
+// is `Serialize`-only in production; tests need to deserialize, so add a
+// permissive Deserialize impl behind cfg(test).)
+#[cfg(test)]
+impl<'de> serde::Deserialize<'de> for AppleNonceResponse {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Helper {
+            nonce: String,
+            expires_in: i64,
+        }
+        let h = Helper::deserialize(deserializer)?;
+        Ok(AppleNonceResponse {
+            nonce: h.nonce,
+            expires_in: h.expires_in,
+        })
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -882,28 +905,5 @@ mod tests {
         let v2: AppleNonceResponse = serde_json::from_slice(&body2).unwrap();
         // Two separate session-less requests must not return the same nonce.
         assert_ne!(v1.nonce, v2.nonce);
-    }
-}
-
-// Allow the binary crate's `Serialize` derive on `AppleNonceResponse` to be
-// reconstructed by tests via `serde_json::from_slice`. (`AppleNonceResponse`
-// is `Serialize`-only in production; tests need to deserialize, so add a
-// permissive Deserialize impl behind cfg(test).)
-#[cfg(test)]
-impl<'de> serde::Deserialize<'de> for AppleNonceResponse {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: serde::Deserializer<'de>,
-    {
-        #[derive(Deserialize)]
-        struct Helper {
-            nonce: String,
-            expires_in: i64,
-        }
-        let h = Helper::deserialize(deserializer)?;
-        Ok(AppleNonceResponse {
-            nonce: h.nonce,
-            expires_in: h.expires_in,
-        })
     }
 }

--- a/src/apple_signin.rs
+++ b/src/apple_signin.rs
@@ -8,19 +8,45 @@
 //! trust Apple directly — they trust AuthNZ, and AuthNZ decides which upstream
 //! sources are acceptable.
 //!
-//! Supported flows:
+//! # Security model
 //!
-//! - Native flow (`/oauth/apple/idtoken`): the iOS app uses
-//!   `ASAuthorizationAppleIDProvider` to obtain an id_token, then POSTs it to
-//!   this server. We validate the signature, map to an Arkavo account, and
-//!   return an Arkavo JWT (or, when called from `/oauth/authorize`, an OIDC
-//!   authorization code).
-//! - Web flow (`/oauth/apple/callback`): scaffolded for completeness. Apple's
-//!   web flow requires a client secret JWT signed by the operator's Apple
-//!   private key. Operators must set `APPLE_TEAM_ID`, `APPLE_KEY_ID`,
-//!   `APPLE_PRIVATE_KEY_PATH`, `APPLE_CLIENT_ID`, and `APPLE_REDIRECT_URI`.
-//!   The code-exchange step against Apple is intentionally left as a TODO in
-//!   the initial OIDC provider PR.
+//! Every accepted Apple id_token must clear the following gates:
+//!
+//! 1. **Signature**: validated against Apple's published JWKS (cached 1h with
+//!    force-refresh on `kid` miss in case Apple rotated keys).
+//! 2. **Issuer**: `iss` must equal `https://appleid.apple.com`.
+//! 3. **Audience**: `aud` must be one of the configured `APPLE_CLIENT_ID` values.
+//!    Multiple values (comma-separated) are supported so a single AuthNZ
+//!    deployment can accept both an iOS bundle id and a web Service ID.
+//! 4. **Nonce**: a server-issued nonce must be supplied via the session, and
+//!    the id_token's `nonce` claim must equal either that raw nonce *or*
+//!    `sha256_hex(raw_nonce)` (Apple's recommended pattern for native clients).
+//!    Replay-prevention rests on this nonce check, so it is mandatory.
+//! 5. **Exp/iat**: enforced by `jsonwebtoken::Validation` (no leeway changes).
+//!
+//! # Supported flows
+//!
+//! - **Native flow** (`/oauth/apple/nonce` + `/oauth/apple/idtoken`): the iOS
+//!   app calls `/oauth/apple/nonce` to obtain a server-issued nonce, uses it as
+//!   the `nonce` field in `ASAuthorizationAppleIDRequest`, then POSTs the
+//!   resulting id_token to `/oauth/apple/idtoken`. Server validates as above
+//!   and returns the persisted Arkavo identity record.
+//! - **OIDC authorize-with-Apple** (`GET /oauth/authorize?idp=apple&...`): the
+//!   relying party's OIDC `nonce` parameter is reused as the Apple nonce. The
+//!   id_token's `nonce` claim must match (raw or sha256_hex). This binds the
+//!   downstream OIDC nonce to the upstream Apple ceremony.
+//! - **Web callback** (`POST /oauth/apple/callback`): intentionally rejected
+//!   until full code-exchange + state-bound-nonce wiring is implemented. The
+//!   endpoint returns HTTP 501 with a clear error so misconfigured Apple
+//!   Service IDs fail loudly instead of being silently accepted.
+//!
+//! # Persistence
+//!
+//! [`map_apple_user`] persists the `apple:<sub> → arkavo_account_id` mapping
+//! in DynamoDB (via the existing credentials table, keyed by an
+//! `apple-<sanitized_sub>` username). Email is treated as optional metadata;
+//! the account key is always Apple's `sub`, so private-relay address changes
+//! do not break identity continuity.
 
 use crate::AppState;
 use crate::constants::{APPLE_ISSUER, APPLE_JWKS_CACHE_TTL_SECONDS, APPLE_JWKS_URL};
@@ -35,10 +61,18 @@ use jsonwebtoken::jwk::{AlgorithmParameters, Jwk};
 use jsonwebtoken::{Algorithm, DecodingKey, Validation, decode, decode_header};
 use log::{debug, error, info, warn};
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use std::env;
 use std::sync::Arc;
 use thiserror::Error;
 use tokio::sync::RwLock;
+use tower_sessions::Session;
+use uuid::Uuid;
+
+const SESSION_APPLE_NONCE_KEY: &str = "apple_nonce_state";
+
+/// Nonce TTL (seconds). Short-lived to bound the replay window.
+const APPLE_NONCE_TTL_SECONDS: i64 = 600;
 
 /// Claims published by Apple in id_tokens.
 ///
@@ -88,10 +122,25 @@ pub enum AppleSigninError {
     UnknownKid(String),
     #[error("Apple id_token signature/claims invalid: {0}")]
     InvalidToken(String),
-    #[error("Apple id_token audience mismatch: expected {expected}, got {actual}")]
-    AudienceMismatch { expected: String, actual: String },
+    #[error("Apple id_token audience mismatch: aud={actual} not in {expected:?}")]
+    AudienceMismatch {
+        expected: Vec<String>,
+        actual: String,
+    },
+    #[error("Apple id_token issuer mismatch: iss={0}")]
+    IssuerMismatch(String),
+    #[error("Apple id_token nonce missing")]
+    MissingTokenNonce,
+    #[error("Apple id_token nonce mismatch")]
+    NonceMismatch,
+    #[error(
+        "No server-issued Apple nonce in session — call GET /oauth/apple/nonce before submitting an id_token"
+    )]
+    MissingSessionNonce,
     #[error("APPLE_CLIENT_ID is not configured")]
     MissingClientId,
+    #[error("session error: {0}")]
+    SessionError(String),
 }
 
 impl IntoResponse for AppleSigninError {
@@ -100,17 +149,25 @@ impl IntoResponse for AppleSigninError {
             AppleSigninError::JwksFetch(_) | AppleSigninError::JwksParse(_) => {
                 StatusCode::BAD_GATEWAY
             }
-            AppleSigninError::MissingClientId => StatusCode::INTERNAL_SERVER_ERROR,
+            AppleSigninError::MissingClientId | AppleSigninError::SessionError(_) => {
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
+            AppleSigninError::MissingSessionNonce => StatusCode::BAD_REQUEST,
             _ => StatusCode::UNAUTHORIZED,
         };
         (status, self.to_string()).into_response()
     }
 }
 
-/// Cached Apple JWKS. Refreshes lazily on cache miss / expiry.
+/// Cached Apple JWKS, plus the operator-configured Apple client IDs.
+///
+/// `client_ids` is parsed from the `APPLE_CLIENT_ID` env var, which accepts a
+/// comma-separated list so a single AuthNZ instance can accept both an iOS
+/// bundle id (used by native Sign in with Apple) and a web Service ID (used by
+/// the web flow) without needing parallel deployments.
 pub struct AppleJwksCache {
     inner: RwLock<CacheState>,
-    client_id: Option<String>,
+    client_ids: Vec<String>,
 }
 
 struct CacheState {
@@ -120,17 +177,27 @@ struct CacheState {
 
 impl AppleJwksCache {
     pub fn new() -> Self {
+        let client_ids = env::var("APPLE_CLIENT_ID")
+            .ok()
+            .map(|raw| {
+                raw.split(',')
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
         Self {
             inner: RwLock::new(CacheState {
                 keys: Vec::new(),
                 fetched_at: 0,
             }),
-            client_id: env::var("APPLE_CLIENT_ID").ok(),
+            client_ids,
         }
     }
 
-    pub fn client_id(&self) -> Option<&str> {
-        self.client_id.as_deref()
+    /// Operator-configured Apple client IDs. Apple `aud` must match one of these.
+    pub fn client_ids(&self) -> &[String] {
+        &self.client_ids
     }
 
     async fn get_keys(&self) -> Result<Vec<Jwk>, AppleSigninError> {
@@ -180,15 +247,23 @@ struct AppleJwksResponse {
     keys: Vec<Jwk>,
 }
 
-/// Verify an Apple-issued id_token. Returns the verified claims on success.
+/// Verify an Apple-issued id_token against the configured Apple client IDs,
+/// Apple's published JWKS, and the supplied server-issued nonce.
+///
+/// `expected_raw_nonce` is the raw, opaque nonce that AuthNZ issued (via
+/// [`issue_apple_nonce`] for the native flow, or the OIDC `nonce` query param
+/// for the authorize flow). The id_token's `nonce` claim must equal either the
+/// raw value or its hex-encoded SHA-256 — Apple recommends clients hash the
+/// nonce before sending it to Apple, so both forms are accepted.
 pub async fn verify_apple_id_token(
     cache: &AppleJwksCache,
     id_token: &str,
+    expected_raw_nonce: &str,
 ) -> Result<AppleIdTokenClaims, AppleSigninError> {
-    let client_id = cache
-        .client_id()
-        .ok_or(AppleSigninError::MissingClientId)?
-        .to_string();
+    let client_ids = cache.client_ids();
+    if client_ids.is_empty() {
+        return Err(AppleSigninError::MissingClientId);
+    }
 
     let header = decode_header(id_token)
         .map_err(|e| AppleSigninError::InvalidToken(format!("header decode: {}", e)))?;
@@ -196,7 +271,7 @@ pub async fn verify_apple_id_token(
 
     let keys = cache.get_keys().await?;
     if let Some(jwk) = find_jwk(&keys, &kid) {
-        return verify_apple_id_token_with_jwk(jwk, id_token, &client_id);
+        return verify_apple_id_token_with_jwk(jwk, id_token, client_ids, expected_raw_nonce);
     }
 
     // Cache miss: force a refresh in case Apple rotated keys.
@@ -204,7 +279,7 @@ pub async fn verify_apple_id_token(
     cache.invalidate().await;
     let keys = cache.get_keys().await?;
     let jwk = find_jwk(&keys, &kid).ok_or_else(|| AppleSigninError::UnknownKid(kid.clone()))?;
-    verify_apple_id_token_with_jwk(jwk, id_token, &client_id)
+    verify_apple_id_token_with_jwk(jwk, id_token, client_ids, expected_raw_nonce)
 }
 
 fn find_jwk<'a>(keys: &'a [Jwk], kid: &str) -> Option<&'a Jwk> {
@@ -220,7 +295,8 @@ fn find_jwk<'a>(keys: &'a [Jwk], kid: &str) -> Option<&'a Jwk> {
 fn verify_apple_id_token_with_jwk(
     jwk: &Jwk,
     id_token: &str,
-    client_id: &str,
+    client_ids: &[String],
+    expected_raw_nonce: &str,
 ) -> Result<AppleIdTokenClaims, AppleSigninError> {
     let alg = match &jwk.algorithm {
         AlgorithmParameters::RSA(_) => Algorithm::RS256,
@@ -237,48 +313,84 @@ fn verify_apple_id_token_with_jwk(
 
     let mut validation = Validation::new(alg);
     validation.set_issuer(&[APPLE_ISSUER]);
-    validation.set_audience(&[client_id]);
+    // jsonwebtoken's set_audience accepts the full list; it succeeds if `aud`
+    // matches *any* configured value, which is what we want for multi-client
+    // deployments (iOS bundle + web Service ID).
+    validation.set_audience(client_ids);
 
     let data = decode::<AppleIdTokenClaims>(id_token, &decoding_key, &validation)
         .map_err(|e| AppleSigninError::InvalidToken(e.to_string()))?;
     let claims = data.claims;
 
-    if claims.aud != client_id {
+    // Defense-in-depth: re-check aud/iss ourselves so a future Validation
+    // misconfiguration can't silently widen the trust boundary.
+    if !client_ids.iter().any(|c| c == &claims.aud) {
         return Err(AppleSigninError::AudienceMismatch {
-            expected: client_id.to_string(),
+            expected: client_ids.to_vec(),
             actual: claims.aud,
         });
     }
     if claims.iss != APPLE_ISSUER {
-        return Err(AppleSigninError::InvalidToken(format!(
-            "iss mismatch: {}",
-            claims.iss
-        )));
+        return Err(AppleSigninError::IssuerMismatch(claims.iss));
     }
+
+    check_nonce(claims.nonce.as_deref(), expected_raw_nonce)?;
 
     Ok(claims)
 }
 
+/// Validate that the id_token's nonce claim binds to the server-issued nonce.
+///
+/// Accepts either the raw nonce verbatim or its hex SHA-256 (Apple's
+/// recommended client-side hashing pattern). Uses constant-time comparison.
+fn check_nonce(
+    token_nonce: Option<&str>,
+    expected_raw_nonce: &str,
+) -> Result<(), AppleSigninError> {
+    let token_nonce = token_nonce.ok_or(AppleSigninError::MissingTokenNonce)?;
+    let hashed = sha256_hex(expected_raw_nonce);
+    if !constant_time_eq(token_nonce, expected_raw_nonce) && !constant_time_eq(token_nonce, &hashed)
+    {
+        return Err(AppleSigninError::NonceMismatch);
+    }
+    Ok(())
+}
+
+fn constant_time_eq(a: &str, b: &str) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.bytes().zip(b.bytes()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
 /// Map verified Apple claims onto an Arkavo account, creating one if needed.
 ///
-/// The mapping uses Apple's stable `sub` claim as the join key. For the first
-/// PR we mint a synthetic DID (`did:key:apple-<sub-hash>`) so the existing
-/// DynamoDB `create_user` path (which requires a `did:key:` DID) keeps working.
-/// A follow-up PR can replace this with a richer Apple-account record.
+/// **Persistence contract**: this function writes to DynamoDB (via the
+/// existing credentials table). Specifically:
+///
+/// - Lookup key: `username = apple-<sanitized_apple_sub>` (DynamoDB
+///   `username-index` GSI). The Apple `sub` is the canonical join key —
+///   email is treated as optional metadata and is *never* used to locate an
+///   account (Apple may rotate private-relay addresses without notice).
+/// - Mapping: `apple:<apple_sub> → arkavo_account_id (UUID)` is rehydrated
+///   on every login from DynamoDB, never from in-memory state or defaults.
+/// - First-login provisioning: creates a real DynamoDB row via
+///   [`crate::db::DynamoDBStore::create_user`] with a deterministic synthetic
+///   `did:key:apple-<sha256(sub)>` DID (the existing schema requires a DID;
+///   a follow-up will add a dedicated Apple-account record).
+///
+/// Roles/entitlements default to a minimal user policy; persisting these
+/// per-account is a tracked follow-up (see README).
 pub async fn map_apple_user(
     app_state: &AppState,
     claims: &AppleIdTokenClaims,
 ) -> Result<AuthenticatedUser, DynamoDBError> {
-    // Use the Apple sub as a deterministic username so we can locate the user
-    // on subsequent logins. The leading `apple-` prefix avoids collisions with
-    // WebAuthn-registered usernames.
     let username = format!("apple-{}", sanitize_for_username(&claims.sub));
-    let did = format!(
-        "did:key:apple-{}",
-        // Truncate to keep DID a sensible length; collisions on the truncated
-        // hash are not relevant because lookups go through `username`.
-        &sha256_hex(&claims.sub)[..32]
-    );
+    let did = format!("did:key:apple-{}", &sha256_hex(&claims.sub)[..32]);
 
     let user = match app_state.db_store.get_user_by_name(&username).await? {
         Some(existing) => existing,
@@ -309,13 +421,86 @@ fn sanitize_for_username(s: &str) -> String {
 }
 
 fn sha256_hex(s: &str) -> String {
-    use sha2::{Digest, Sha256};
     let mut hasher = Sha256::new();
     hasher.update(s.as_bytes());
     hex::encode(hasher.finalize())
 }
 
+// --------- Nonce session helpers ---------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct AppleNonceState {
+    raw_nonce: String,
+    expires_at: i64,
+}
+
+/// Issue a fresh server-side Apple nonce, persist it in the session, and
+/// return the raw value. The session is the binding between this nonce and
+/// the subsequent `/oauth/apple/idtoken` call from the same client.
+pub async fn issue_apple_nonce(session: &Session) -> Result<String, AppleSigninError> {
+    // 256 bits of entropy from two UUIDs concatenated and base64url-encoded.
+    let part1 = Uuid::new_v4();
+    let part2 = Uuid::new_v4();
+    let mut bytes = Vec::with_capacity(32);
+    bytes.extend_from_slice(part1.as_bytes());
+    bytes.extend_from_slice(part2.as_bytes());
+    let raw_nonce =
+        base64::Engine::encode(&base64::engine::general_purpose::URL_SAFE_NO_PAD, bytes);
+
+    let state = AppleNonceState {
+        raw_nonce: raw_nonce.clone(),
+        expires_at: Utc::now().timestamp() + APPLE_NONCE_TTL_SECONDS,
+    };
+    session
+        .insert(SESSION_APPLE_NONCE_KEY, &state)
+        .await
+        .map_err(|e| AppleSigninError::SessionError(e.to_string()))?;
+    Ok(raw_nonce)
+}
+
+/// Single-use consume of the session-stored Apple nonce.
+async fn consume_apple_nonce(session: &Session) -> Result<String, AppleSigninError> {
+    let state: AppleNonceState = session
+        .get(SESSION_APPLE_NONCE_KEY)
+        .await
+        .map_err(|e| AppleSigninError::SessionError(e.to_string()))?
+        .ok_or(AppleSigninError::MissingSessionNonce)?;
+    // Clear immediately — single-use, regardless of whether validation succeeds.
+    session
+        .remove_value(SESSION_APPLE_NONCE_KEY)
+        .await
+        .map_err(|e| AppleSigninError::SessionError(e.to_string()))?;
+
+    if state.expires_at < Utc::now().timestamp() {
+        return Err(AppleSigninError::MissingSessionNonce);
+    }
+    Ok(state.raw_nonce)
+}
+
 // --------- HTTP handlers ---------
+
+#[derive(Debug, Serialize)]
+pub struct AppleNonceResponse {
+    /// Opaque server-issued nonce. Pass this value to
+    /// `ASAuthorizationAppleIDRequest.nonce` (or its hex SHA-256, per Apple's
+    /// recommendation). The same `Session` cookie must accompany the eventual
+    /// `POST /oauth/apple/idtoken` so the server can match the nonce.
+    pub nonce: String,
+    pub expires_in: i64,
+}
+
+/// Issue a server-side Apple nonce. Required step before
+/// `POST /oauth/apple/idtoken` in the native flow.
+pub async fn apple_nonce_handler(session: Session) -> Response {
+    match issue_apple_nonce(&session).await {
+        Ok(nonce) => Json(AppleNonceResponse {
+            nonce,
+            expires_in: APPLE_NONCE_TTL_SECONDS,
+        })
+        .into_response(),
+        Err(e) => e.into_response(),
+    }
+}
 
 #[derive(Debug, Deserialize)]
 pub struct AppleIdTokenRequest {
@@ -331,20 +516,24 @@ pub struct AppleIdTokenResponse {
     pub email_verified: Option<bool>,
 }
 
-/// Native flow: exchange an Apple-issued id_token for an Arkavo identity record.
+/// Native flow: exchange an Apple-issued id_token (with a previously issued
+/// nonce) for an Arkavo identity record.
 ///
-/// This endpoint is primarily intended for native iOS clients that have
-/// already completed the Sign in with Apple ceremony on-device. The response
-/// is informational; to obtain OIDC tokens for downstream relying parties,
-/// the client should call `/oauth/authorize` with `idp=apple` and the same
-/// id_token in either the `id_token` query param or the `X-Apple-Id-Token`
-/// header.
+/// Required preamble: client must have called `GET /oauth/apple/nonce` on the
+/// same session. The id_token's `nonce` claim must match the session-stored
+/// raw nonce, either verbatim or as hex SHA-256.
 pub async fn apple_idtoken_handler(
     Extension(app_state): Extension<AppState>,
     Extension(cache): Extension<Arc<AppleJwksCache>>,
+    session: Session,
     Json(req): Json<AppleIdTokenRequest>,
 ) -> Response {
-    let claims = match verify_apple_id_token(&cache, &req.id_token).await {
+    let raw_nonce = match consume_apple_nonce(&session).await {
+        Ok(n) => n,
+        Err(e) => return e.into_response(),
+    };
+
+    let claims = match verify_apple_id_token(&cache, &req.id_token, &raw_nonce).await {
         Ok(c) => c,
         Err(e) => return e.into_response(),
     };
@@ -380,63 +569,38 @@ pub struct AppleCallbackForm {
     pub error: Option<String>,
 }
 
-/// Web flow callback. Apple POSTs (`response_mode=form_post`) the code and
-/// id_token to this endpoint after the user authenticates on appleid.apple.com.
+#[derive(Debug, Serialize)]
+struct ErrorBody {
+    error: &'static str,
+    error_description: &'static str,
+}
+
+/// Web flow callback — currently rejected unconditionally.
 ///
-/// For now we only support the path where Apple includes the id_token directly
-/// (which it does when `response_mode=form_post` + `scope=name email` are set).
-/// Exchanging `code` for tokens against Apple's `/auth/token` endpoint
-/// requires signing a client secret JWT with the operator's Apple private key
-/// — left as a follow-up.
-pub async fn apple_callback_handler(
-    Extension(app_state): Extension<AppState>,
-    Extension(cache): Extension<Arc<AppleJwksCache>>,
-    Json(form): Json<AppleCallbackForm>,
-) -> Response {
-    if let Some(err) = form.error {
-        return (StatusCode::BAD_REQUEST, format!("apple_error: {}", err)).into_response();
-    }
-    let id_token = match form.id_token {
-        Some(t) => t,
-        None => {
-            debug!(
-                "Apple callback received code but no id_token; code exchange not yet implemented"
-            );
-            return (
-                StatusCode::NOT_IMPLEMENTED,
-                "Apple callback requires id_token in form post. \
-                 Apple code-exchange flow is not yet implemented; configure your \
-                 Apple Service ID with response_mode=form_post and scope=name+email \
-                 so id_token is delivered directly.",
-            )
-                .into_response();
-        }
-    };
-
-    let claims = match verify_apple_id_token(&cache, &id_token).await {
-        Ok(c) => c,
-        Err(e) => return e.into_response(),
-    };
-    let user = match map_apple_user(&app_state, &claims).await {
-        Ok(u) => u,
-        Err(e) => {
-            error!("Failed to map Apple user: {}", e);
-            return (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to provision Arkavo account: {}", e),
-            )
-                .into_response();
-        }
-    };
-
-    Json(AppleIdTokenResponse {
-        arkavo_account_id: user.arkavo_account_id,
-        subject: user.subject,
-        idp: user.idp,
-        email: user.email,
-        email_verified: user.email_verified,
-    })
-    .into_response()
+/// The Apple web flow requires both:
+/// 1. A code-exchange step against `https://appleid.apple.com/auth/token`
+///    using a JWT signed with the operator's Apple private key, and
+/// 2. State-bound nonce verification so the callback can be tied to the
+///    original `/authorize` request without trusting attacker-supplied input.
+///
+/// Until both are implemented this endpoint returns HTTP 501. This is the
+/// "clearly rejects" path required by the security review — we never accept
+/// an Apple id_token through this endpoint without nonce verification, even
+/// if the form post happens to include one.
+pub async fn apple_callback_handler(Json(_form): Json<AppleCallbackForm>) -> Response {
+    debug!("Rejecting Apple web callback — code exchange + state-bound nonce not implemented");
+    (
+        StatusCode::NOT_IMPLEMENTED,
+        Json(ErrorBody {
+            error: "apple_web_callback_disabled",
+            error_description:
+                "Apple web callback is intentionally disabled until code exchange and \
+                 state-bound nonce verification are implemented. Use the native flow \
+                 (GET /oauth/apple/nonce + POST /oauth/apple/idtoken) or the OIDC \
+                 authorize endpoint with idp=apple instead.",
+        }),
+    )
+        .into_response()
 }
 
 #[cfg(test)]
@@ -495,6 +659,26 @@ mod tests {
             AppleSigninError::MissingClientId.into_response().status(),
             StatusCode::INTERNAL_SERVER_ERROR
         );
+        assert_eq!(
+            AppleSigninError::NonceMismatch.into_response().status(),
+            StatusCode::UNAUTHORIZED
+        );
+        assert_eq!(
+            AppleSigninError::MissingTokenNonce.into_response().status(),
+            StatusCode::UNAUTHORIZED
+        );
+        assert_eq!(
+            AppleSigninError::MissingSessionNonce
+                .into_response()
+                .status(),
+            StatusCode::BAD_REQUEST
+        );
+        assert_eq!(
+            AppleSigninError::IssuerMismatch("https://evil.example".into())
+                .into_response()
+                .status(),
+            StatusCode::UNAUTHORIZED
+        );
     }
 
     #[test]
@@ -505,13 +689,221 @@ mod tests {
             "aud":"com.arkavo.app",
             "iat":1700000000,
             "exp":1700003600,
+            "nonce":"abc",
             "email":"user@privaterelay.appleid.com",
             "email_verified":"true",
             "is_private_email":true
         }"#;
         let claims: AppleIdTokenClaims = serde_json::from_str(json).unwrap();
         assert_eq!(claims.sub, "000123.abc");
+        assert_eq!(claims.nonce.as_deref(), Some("abc"));
         assert!(claims.email_verified.unwrap().as_bool());
         assert!(claims.is_private_email.unwrap().as_bool());
+    }
+
+    #[test]
+    fn test_constant_time_eq() {
+        assert!(constant_time_eq("hello", "hello"));
+        assert!(!constant_time_eq("hello", "world"));
+        assert!(!constant_time_eq("hello", "hello!"));
+        assert!(!constant_time_eq("", "x"));
+    }
+
+    #[test]
+    fn test_multiple_client_ids_parsed() {
+        // Note: we don't use AppleJwksCache::new() here because it reads env;
+        // instead validate the parsing logic directly.
+        let raw = "com.arkavo.app, com.arkavo.web , com.arkavo.macos";
+        let parsed: Vec<String> = raw
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        assert_eq!(
+            parsed,
+            vec![
+                "com.arkavo.app".to_string(),
+                "com.arkavo.web".to_string(),
+                "com.arkavo.macos".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_audience_mismatch_lists_expected() {
+        let err = AppleSigninError::AudienceMismatch {
+            expected: vec!["com.arkavo.app".into(), "com.arkavo.web".into()],
+            actual: "evil.example".into(),
+        };
+        let msg = err.to_string();
+        assert!(msg.contains("com.arkavo.app"));
+        assert!(msg.contains("com.arkavo.web"));
+        assert!(msg.contains("evil.example"));
+    }
+
+    #[test]
+    fn test_check_nonce_accepts_verbatim() {
+        let raw = "raw-nonce-12345";
+        assert!(check_nonce(Some(raw), raw).is_ok());
+    }
+
+    #[test]
+    fn test_check_nonce_accepts_sha256_hex() {
+        let raw = "raw-nonce-12345";
+        let hashed = sha256_hex(raw);
+        assert!(check_nonce(Some(&hashed), raw).is_ok());
+    }
+
+    #[test]
+    fn test_check_nonce_rejects_mismatch() {
+        let raw = "raw-nonce-12345";
+        assert!(matches!(
+            check_nonce(Some("not-the-nonce"), raw),
+            Err(AppleSigninError::NonceMismatch)
+        ));
+    }
+
+    #[test]
+    fn test_check_nonce_rejects_missing() {
+        assert!(matches!(
+            check_nonce(None, "raw-nonce"),
+            Err(AppleSigninError::MissingTokenNonce)
+        ));
+    }
+
+    #[test]
+    fn test_check_nonce_rejects_empty_string_when_raw_is_nonempty() {
+        // An attacker sending an id_token whose nonce is empty must not pass.
+        assert!(matches!(
+            check_nonce(Some(""), "raw"),
+            Err(AppleSigninError::NonceMismatch)
+        ));
+    }
+
+    #[test]
+    fn test_check_nonce_rejects_hash_of_wrong_value() {
+        let other_hashed = sha256_hex("other-nonce");
+        assert!(matches!(
+            check_nonce(Some(&other_hashed), "expected-nonce"),
+            Err(AppleSigninError::NonceMismatch)
+        ));
+    }
+
+    #[test]
+    fn test_apple_subject_is_account_key_not_email() {
+        // The mapping uses Apple sub for username derivation. Construct a
+        // claims value with a non-empty sub but no email; confirm the
+        // derived username is the same regardless of email rotation.
+        let sub = "000abc.123def";
+        let username = format!("apple-{}", sanitize_for_username(sub));
+        assert_eq!(username, "apple-000abc.123def");
+        // Email rotation must not affect the deterministic key.
+        let same = format!("apple-{}", sanitize_for_username(sub));
+        assert_eq!(username, same);
+    }
+
+    #[tokio::test]
+    async fn test_apple_web_callback_returns_501() {
+        use axum::Router;
+        use axum::body::Body;
+        use axum::http::Request;
+        use axum::routing::post;
+        use tower::ServiceExt;
+
+        let app = Router::new().route("/oauth/apple/callback", post(apple_callback_handler));
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/oauth/apple/callback")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        r#"{"code":"X","id_token":"Y","state":"S"}"#.to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_IMPLEMENTED);
+        let body = axum::body::to_bytes(response.into_body(), 4096)
+            .await
+            .unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v["error"], "apple_web_callback_disabled");
+    }
+
+    #[tokio::test]
+    async fn test_apple_nonce_endpoint_issues_unique_values_and_persists() {
+        use axum::Router;
+        use axum::body::Body;
+        use axum::http::Request;
+        use axum::routing::get;
+        use tower::ServiceExt;
+        use tower_sessions::cookie::SameSite;
+        use tower_sessions::cookie::time::Duration as SessionDuration;
+        use tower_sessions::{Expiry, MemoryStore, SessionManagerLayer};
+
+        let session_layer = SessionManagerLayer::new(MemoryStore::default())
+            .with_name("authnz-rs-test")
+            .with_same_site(SameSite::Strict)
+            .with_secure(false)
+            .with_expiry(Expiry::OnInactivity(SessionDuration::seconds(600)));
+
+        let app = Router::new()
+            .route("/oauth/apple/nonce", get(apple_nonce_handler))
+            .layer(session_layer);
+
+        let resp1 = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/oauth/apple/nonce")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp1.status(), StatusCode::OK);
+        let body1 = axum::body::to_bytes(resp1.into_body(), 4096).await.unwrap();
+        let v1: AppleNonceResponse = serde_json::from_slice(&body1).unwrap();
+        assert!(!v1.nonce.is_empty());
+        assert_eq!(v1.expires_in, APPLE_NONCE_TTL_SECONDS);
+
+        let resp2 = app
+            .oneshot(
+                Request::builder()
+                    .uri("/oauth/apple/nonce")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body2 = axum::body::to_bytes(resp2.into_body(), 4096).await.unwrap();
+        let v2: AppleNonceResponse = serde_json::from_slice(&body2).unwrap();
+        // Two separate session-less requests must not return the same nonce.
+        assert_ne!(v1.nonce, v2.nonce);
+    }
+}
+
+// Allow the binary crate's `Serialize` derive on `AppleNonceResponse` to be
+// reconstructed by tests via `serde_json::from_slice`. (`AppleNonceResponse`
+// is `Serialize`-only in production; tests need to deserialize, so add a
+// permissive Deserialize impl behind cfg(test).)
+#[cfg(test)]
+impl<'de> serde::Deserialize<'de> for AppleNonceResponse {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct Helper {
+            nonce: String,
+            expires_in: i64,
+        }
+        let h = Helper::deserialize(deserializer)?;
+        Ok(AppleNonceResponse {
+            nonce: h.nonce,
+            expires_in: h.expires_in,
+        })
     }
 }

--- a/src/authn.rs
+++ b/src/authn.rs
@@ -338,7 +338,7 @@ pub async fn finish_authentication(
         return Err(WebauthnError::InvalidSessionState(err));
     }
 
-    let res = match app_state
+    match app_state
         .webauthn
         .finish_passkey_authentication(&auth, &auth_state)
     {
@@ -358,8 +358,7 @@ pub async fn finish_authentication(
                 }),
             ))
         }
-    };
-    res
+    }
 }
 
 // Existing helper functions and structs remain the same

--- a/src/authn.rs
+++ b/src/authn.rs
@@ -1,10 +1,10 @@
+use crate::AppState;
 use crate::authn::WebauthnError::{
     CorruptSession, InvalidSessionState, MissingToken, TokenCreationError, Unknown,
     UserHasNoCredentials, UserNotFound,
 };
 use crate::constants::{AUTH_TOKEN_HOURS, REGISTRATION_TOKEN_WEEKS};
 use crate::db::DynamoDBError;
-use crate::AppState;
 use axum::extract::Query;
 use axum::http::{HeaderMap, HeaderValue};
 use axum::response::Response;
@@ -16,7 +16,7 @@ use axum::{
 use chrono::Utc;
 use ecdsa::signature::{Signer, Verifier};
 use ecdsa::{Signature, VerifyingKey};
-use jsonwebtoken::{decode, encode, Algorithm, Header, TokenData, Validation};
+use jsonwebtoken::{Algorithm, Header, TokenData, Validation, decode, encode};
 use log::{error, info};
 use p256::NistP256;
 use serde::{Deserialize, Serialize};

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -33,3 +33,6 @@ pub const APPLE_JWKS_URL: &str = "https://appleid.apple.com/auth/keys";
 
 /// Apple OIDC issuer (used to validate `iss` claim on Apple id_tokens)
 pub const APPLE_ISSUER: &str = "https://appleid.apple.com";
+
+/// OIDC refresh token lifetime in seconds (30 days)
+pub const REFRESH_TOKEN_LIFETIME_SECONDS: i64 = 2592000;

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -12,3 +12,24 @@ pub const AUTH_TOKEN_HOURS: i64 = 1;
 
 /// Session inactivity timeout in seconds (10 minutes)
 pub const SESSION_TIMEOUT_SECONDS: i64 = 600;
+
+/// OIDC issuer URL (default; can be overridden via OIDC_ISSUER env var)
+pub const DEFAULT_OIDC_ISSUER: &str = "https://identity.arkavo.net";
+
+/// OIDC ID token lifetime in seconds (1 hour)
+pub const ID_TOKEN_LIFETIME_SECONDS: i64 = 3600;
+
+/// OIDC access token lifetime in seconds (1 hour)
+pub const ACCESS_TOKEN_LIFETIME_SECONDS: i64 = 3600;
+
+/// OIDC authorization code lifetime in seconds (10 minutes)
+pub const AUTHORIZATION_CODE_LIFETIME_SECONDS: i64 = 600;
+
+/// Apple JWKS cache TTL in seconds (1 hour). Apple rotates keys infrequently.
+pub const APPLE_JWKS_CACHE_TTL_SECONDS: i64 = 3600;
+
+/// Apple JWKS URL
+pub const APPLE_JWKS_URL: &str = "https://appleid.apple.com/auth/keys";
+
+/// Apple OIDC issuer (used to validate `iss` claim on Apple id_tokens)
+pub const APPLE_ISSUER: &str = "https://appleid.apple.com";

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,6 +1,6 @@
+use aws_sdk_dynamodb::Client;
 use aws_sdk_dynamodb::error::SdkError;
 use aws_sdk_dynamodb::types::AttributeValue;
-use aws_sdk_dynamodb::Client;
 use log::{error, info, warn};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
@@ -161,7 +161,9 @@ impl DynamoDBStore {
                     SdkError::ServiceError(ref service_error) => {
                         if service_error.err().meta().code() == Some("ResourceNotFoundException") {
                             // If handles table doesn't exist, log warning but don't fail the registration
-                            warn!("Handles table does not exist - handle will need to be created later");
+                            warn!(
+                                "Handles table does not exist - handle will need to be created later"
+                            );
                         } else {
                             error!("Failed to write to handles table: {:?}", err);
                             // Attempt to rollback credentials entry
@@ -497,9 +499,7 @@ impl DynamoDBStore {
                 SdkError::ServiceError(ref service_error) => {
                     if service_error.err().meta().code() == Some("ResourceNotFoundException") {
                         error!("Device bindings table does not exist");
-                        return Err(DynamoDBError::TableNotExists(
-                            "device_bindings".to_string(),
-                        ));
+                        return Err(DynamoDBError::TableNotExists("device_bindings".to_string()));
                     }
                     error!("Failed to write to device bindings table: {:?}", err);
                     Err(DynamoDBError::SdkError(err.to_string()))
@@ -580,7 +580,10 @@ impl DynamoDBStore {
             .condition_expression("#counter = :expected_counter")
             .expression_attribute_names("#counter", "counter")
             .expression_attribute_values(":counter", AttributeValue::N(new_counter.to_string()))
-            .expression_attribute_values(":expected_counter", AttributeValue::N(expected_counter.to_string()))
+            .expression_attribute_values(
+                ":expected_counter",
+                AttributeValue::N(expected_counter.to_string()),
+            )
             .expression_attribute_values(":updated_at", AttributeValue::N(updated_at.to_string()))
             .send()
             .await
@@ -592,14 +595,17 @@ impl DynamoDBStore {
             Err(err) => {
                 match &err {
                     SdkError::ServiceError(service_error) => {
-                        if service_error.err().meta().code() == Some("ConditionalCheckFailedException") {
+                        if service_error.err().meta().code()
+                            == Some("ConditionalCheckFailedException")
+                        {
                             error!(
                                 "Counter update race condition detected for device {}: expected {}, but counter was modified",
                                 device_id, expected_counter
                             );
-                            return Err(DynamoDBError::Internal(
-                                format!("Counter race condition: expected counter {}, but it was modified by another request", expected_counter)
-                            ));
+                            return Err(DynamoDBError::Internal(format!(
+                                "Counter race condition: expected counter {}, but it was modified by another request",
+                                expected_counter
+                            )));
                         }
                     }
                     _ => {}

--- a/src/db.rs
+++ b/src/db.rs
@@ -594,19 +594,18 @@ impl DynamoDBStore {
             }
             Err(err) => {
                 match &err {
-                    SdkError::ServiceError(service_error) => {
+                    SdkError::ServiceError(service_error)
                         if service_error.err().meta().code()
-                            == Some("ConditionalCheckFailedException")
-                        {
-                            error!(
-                                "Counter update race condition detected for device {}: expected {}, but counter was modified",
-                                device_id, expected_counter
-                            );
-                            return Err(DynamoDBError::Internal(format!(
-                                "Counter race condition: expected counter {}, but it was modified by another request",
-                                expected_counter
-                            )));
-                        }
+                            == Some("ConditionalCheckFailedException") =>
+                    {
+                        error!(
+                            "Counter update race condition detected for device {}: expected {}, but counter was modified",
+                            device_id, expected_counter
+                        );
+                        return Err(DynamoDBError::Internal(format!(
+                            "Counter race condition: expected counter {}, but it was modified by another request",
+                            expected_counter
+                        )));
                     }
                     _ => {}
                 }
@@ -704,9 +703,12 @@ mod tests {
     #[test]
     fn test_username_validation() {
         // Empty username should be rejected
-        assert!("".is_empty());
-        assert!(!"alice".is_empty());
-        assert!(!"user123".is_empty());
+        let empty = "";
+        let alice = "alice";
+        let user123 = "user123";
+        assert!(empty.is_empty());
+        assert!(!alice.is_empty());
+        assert!(!user123.is_empty());
     }
 
     #[test]

--- a/src/device_check.rs
+++ b/src/device_check.rs
@@ -144,6 +144,7 @@ struct AttestationObject {
 }
 
 #[derive(Debug, Deserialize)]
+#[allow(dead_code)]
 struct AttestationStatement {
     x5c: Vec<Vec<u8>>,
     receipt: Option<Vec<u8>>,
@@ -273,7 +274,7 @@ pub async fn finish_attestation(
     warn!(
         "SECURITY: Nonce validation against certificate extension not implemented. \
          Calculated nonce: {}. This check should be added before production use.",
-        hex::encode(&calculated_nonce)
+        hex::encode(calculated_nonce)
     );
 
     // Get user from database
@@ -486,6 +487,7 @@ fn extract_public_key_from_cert(cert_der: &[u8]) -> Result<Vec<u8>, DeviceCheckE
 }
 
 #[derive(Debug)]
+#[allow(dead_code)]
 struct AuthenticatorData {
     rp_id_hash: Vec<u8>,
     rp_id_hash_str: String,
@@ -748,7 +750,7 @@ mod tests {
 
         // Invalid: counter doesn't increment
         let invalid_counter = 5u32;
-        assert!(!(invalid_counter > old_counter));
+        assert!(invalid_counter <= old_counter);
     }
 
     #[test]

--- a/src/device_check.rs
+++ b/src/device_check.rs
@@ -46,29 +46,29 @@
 //! - Entitlement: `com.apple.developer.devicecheck.appattest-environment`
 //! - Not available in iOS Simulator
 
+use crate::AppState;
 use crate::constants::AUTH_TOKEN_HOURS;
 use crate::db::DynamoDBError;
-use crate::AppState;
 use axum::http::HeaderMap;
 use axum::{
     extract::{Extension, Json, Path},
     http::StatusCode,
     response::IntoResponse,
 };
+use base64::Engine;
 use chrono::Utc;
-use jsonwebtoken::{decode, encode, Algorithm, Header, Validation};
+use ecdsa::signature::Verifier;
+use jsonwebtoken::{Algorithm, Header, Validation, decode, encode};
 use log::{error, info, warn};
+use p256::ecdsa::{Signature as P256Signature, VerifyingKey as P256VerifyingKey};
+use p256::pkcs8::DecodePublicKey;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use std::sync::OnceLock;
 use thiserror::Error;
 use tower_sessions::Session;
 use uuid::Uuid;
 use x509_parser::prelude::*;
-use base64::Engine;
-use ecdsa::signature::Verifier;
-use p256::ecdsa::{Signature as P256Signature, VerifyingKey as P256VerifyingKey};
-use p256::pkcs8::DecodePublicKey;
-use std::sync::OnceLock;
 
 const SESSION_ATTEST_STATE_KEY: &str = "attest_state";
 const SESSION_ASSERT_STATE_KEY: &str = "assert_state";
@@ -120,7 +120,7 @@ pub struct AttestationRequest {
 #[derive(Debug, Deserialize)]
 pub struct AssertionRequest {
     pub key_id: String,
-    pub assertion: String,      // Base64 encoded
+    pub assertion: String,        // Base64 encoded
     pub client_data_hash: String, // Base64 encoded (SHA256 of challenge)
 }
 
@@ -162,7 +162,10 @@ pub async fn generate_challenge(
 
     // Store challenge in session for verification
     if let Err(err) = session
-        .insert(SESSION_ATTEST_STATE_KEY, (username.clone(), challenge.clone()))
+        .insert(
+            SESSION_ATTEST_STATE_KEY,
+            (username.clone(), challenge.clone()),
+        )
         .await
     {
         error!("Failed to save attestation state: {:?}", err);
@@ -179,7 +182,10 @@ pub async fn finish_attestation(
     session: Session,
     Json(request): Json<AttestationRequest>,
 ) -> Result<impl IntoResponse, DeviceCheckError> {
-    info!("Finishing App Attest attestation for key_id: {}", request.key_id);
+    info!(
+        "Finishing App Attest attestation for key_id: {}",
+        request.key_id
+    );
 
     // Retrieve challenge from session
     let (username, challenge): (String, String) = session
@@ -337,7 +343,10 @@ pub async fn generate_assertion_challenge(
 
     // Store challenge in session
     if let Err(err) = session
-        .insert(SESSION_ASSERT_STATE_KEY, (username.clone(), challenge.clone()))
+        .insert(
+            SESSION_ASSERT_STATE_KEY,
+            (username.clone(), challenge.clone()),
+        )
         .await
     {
         error!("Failed to save assertion state: {:?}", err);
@@ -409,11 +418,7 @@ pub async fn finish_assertion(
     // Verify signature using stored public key
     // The assertion contains authenticator data + signature
     // Signature is over: authData || clientDataHash
-    verify_assertion_signature(
-        &assertion_bytes,
-        &client_data_hash,
-        &binding.public_key,
-    )?;
+    verify_assertion_signature(&assertion_bytes, &client_data_hash, &binding.public_key)?;
 
     // Update counter in database with race condition protection
     // Only update if the counter hasn't been modified by another request
@@ -526,12 +531,14 @@ fn verify_assertion_signature(
     let signature_bytes = &assertion_bytes[auth_data_len..];
 
     // Parse the P-256 public key from DER format
-    let verifying_key = P256VerifyingKey::from_public_key_der(public_key_der)
-        .map_err(|e| DeviceCheckError::InvalidCertificateChain(format!("Failed to parse public key: {}", e)))?;
+    let verifying_key = P256VerifyingKey::from_public_key_der(public_key_der).map_err(|e| {
+        DeviceCheckError::InvalidCertificateChain(format!("Failed to parse public key: {}", e))
+    })?;
 
     // Create signature object
-    let signature = P256Signature::from_slice(signature_bytes)
-        .map_err(|e| DeviceCheckError::InvalidAssertion(format!("Invalid signature format: {}", e)))?;
+    let signature = P256Signature::from_slice(signature_bytes).map_err(|e| {
+        DeviceCheckError::InvalidAssertion(format!("Invalid signature format: {}", e))
+    })?;
 
     // The signed data is: authenticatorData || clientDataHash
     let mut signed_data = Vec::new();
@@ -753,10 +760,12 @@ mod tests {
 
         let result = verify_assertion_signature(&short_assertion, &client_data, &public_key);
         assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("too short to contain signature"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("too short to contain signature")
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use fred::interfaces::ClientLike;
 use std::collections::HashMap;
 use std::env;
 use std::fs::File;
@@ -38,8 +39,8 @@ use crate::device_check::{
     finish_assertion, finish_attestation, generate_assertion_challenge, generate_challenge,
 };
 use crate::oidc::{
-    AuthorizationCodeStore, OidcConfig, authorize as oidc_authorize, discovery as oidc_discovery,
-    jwks as oidc_jwks, token as oidc_token, userinfo as oidc_userinfo,
+    AuthorizationCodeStore, OidcConfig, RefreshTokenStore, authorize as oidc_authorize,
+    discovery as oidc_discovery, jwks as oidc_jwks, token as oidc_token, userinfo as oidc_userinfo,
 };
 
 mod apple_signin;
@@ -253,12 +254,35 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         decoding_key: Arc::new(decoding_key),
     };
 
+    // Set up Redis Client using fred
+    let redis_url = env::var("REDIS_URL").unwrap_or_else(|_| "redis://127.0.0.1:6379".to_string());
+    let redis_config = fred::types::RedisConfig::from_url(&redis_url).unwrap_or_else(|_| {
+        log::warn!(
+            "Invalid REDIS_URL '{}', falling back to default config",
+            redis_url
+        );
+        fred::types::RedisConfig::default()
+    });
+    let redis_client = fred::clients::RedisClient::new(redis_config, None, None, None);
+
+    // Spawn connection in the background so a connection failure doesn't crash app startup
+    let redis_conn_client = redis_client.clone();
+    tokio::spawn(async move {
+        let _conn_handle = redis_conn_client.connect();
+        if let Err(err) = redis_conn_client.wait_for_connect().await {
+            log::error!("Failed to connect to Redis: {:?}", err);
+        } else {
+            log::info!("Successfully connected to Redis");
+        }
+    });
+
     // OIDC provider configuration (issuer, JWKS, registered clients).
     let oidc_config = Arc::new(
         OidcConfig::from_env(&settings.decoding_key_path)
             .map_err(|e| format!("Failed to load OIDC configuration: {}", e))?,
     );
-    let oidc_code_store = AuthorizationCodeStore::new();
+    let oidc_code_store = AuthorizationCodeStore::new(redis_client.clone());
+    let oidc_refresh_store = RefreshTokenStore::new(redis_client);
     let apple_jwks_cache = Arc::new(AppleJwksCache::new());
 
     let session_store = MemoryStore::default();
@@ -307,6 +331,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .layer(Extension(app_state))
         .layer(Extension(oidc_config))
         .layer(Extension(oidc_code_store))
+        .layer(Extension(oidc_refresh_store))
         .layer(Extension(apple_jwks_cache))
         .layer(session_service)
         .layer(Extension(apple_app_site_association))

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,9 @@ use tower_sessions::cookie::time::Duration;
 use tower_sessions::{Expiry, MemoryStore, SessionManagerLayer};
 use webauthn_rs::prelude::*;
 
-use crate::apple_signin::{AppleJwksCache, apple_callback_handler, apple_idtoken_handler};
+use crate::apple_signin::{
+    AppleJwksCache, apple_callback_handler, apple_idtoken_handler, apple_nonce_handler,
+};
 use crate::authn::{finish_authentication, finish_register, start_authentication, start_register};
 use crate::constants::SESSION_TIMEOUT_SECONDS;
 use crate::db::DynamoDBStore;
@@ -285,6 +287,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .route("/oauth/token", post(oidc_token))
         .route("/oauth/userinfo", get(oidc_userinfo))
         // Sign in with Apple
+        .route("/oauth/apple/nonce", get(apple_nonce_handler))
         .route("/oauth/apple/idtoken", post(apple_idtoken_handler))
         .route("/oauth/apple/callback", post(apple_callback_handler))
         // Existing OAuth callback for native-app deep links (Patreon/Twitch/Discord/Reddit)

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,34 +11,41 @@ use axum::response::{IntoResponse, Redirect, Response};
 use axum::routing::{get, head, post};
 use axum::{Extension, Router};
 use ecdsa::SigningKey;
-use rustls::ServerConfig;
-use rustls_pemfile::{certs, private_key};
-use tokio_rustls::TlsAcceptor;
 use http::Uri;
-use tower::Service;
-#[cfg(feature = "http3")]
-use quinn::crypto::rustls::QuicServerConfig;
 use jsonwebtoken::{DecodingKey, EncodingKey};
 use log::{debug, error};
 use p256::{NistP256, SecretKey};
+#[cfg(feature = "http3")]
+use quinn::crypto::rustls::QuicServerConfig;
+use rustls::ServerConfig;
+use rustls_pemfile::{certs, private_key};
 use tokio::sync::RwLock;
+use tokio_rustls::TlsAcceptor;
+use tower::Service;
 use tower::ServiceBuilder;
-use tower_sessions::cookie::time::Duration;
 use tower_sessions::cookie::SameSite;
+use tower_sessions::cookie::time::Duration;
 use tower_sessions::{Expiry, MemoryStore, SessionManagerLayer};
 use webauthn_rs::prelude::*;
 
+use crate::apple_signin::{AppleJwksCache, apple_callback_handler, apple_idtoken_handler};
 use crate::authn::{finish_authentication, finish_register, start_authentication, start_register};
 use crate::constants::SESSION_TIMEOUT_SECONDS;
 use crate::db::DynamoDBStore;
 use crate::device_check::{
     finish_assertion, finish_attestation, generate_assertion_challenge, generate_challenge,
 };
+use crate::oidc::{
+    AuthorizationCodeStore, OidcConfig, authorize as oidc_authorize, discovery as oidc_discovery,
+    jwks as oidc_jwks, token as oidc_token, userinfo as oidc_userinfo,
+};
 
+mod apple_signin;
 mod authn;
 mod constants;
 mod db;
 mod device_check;
+mod oidc;
 
 // HTTP/3 server function (feature-gated)
 #[cfg(feature = "http3")]
@@ -70,9 +77,8 @@ async fn run_h3_server(
     server_config.alpn_protocols = vec![b"h3".to_vec()];
 
     // Create Quinn server config
-    let mut quinn_server_config = quinn::ServerConfig::with_crypto(Arc::new(
-        QuicServerConfig::try_from(server_config)?
-    ));
+    let mut quinn_server_config =
+        quinn::ServerConfig::with_crypto(Arc::new(QuicServerConfig::try_from(server_config)?));
 
     let transport_config = Arc::get_mut(&mut quinn_server_config.transport).unwrap();
     transport_config.max_concurrent_uni_streams(100_u8.into());
@@ -146,10 +152,7 @@ async fn handle_h3_request(
 
     // Call the router (this is simplified - production would need proper integration)
     // For now, just return a basic response
-    let response = http::Response::builder()
-        .status(200)
-        .body(())
-        .unwrap();
+    let response = http::Response::builder().status(200).body(()).unwrap();
 
     stream.send_response(response).await?;
     stream.finish().await?;
@@ -186,8 +189,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Set up TLS if enabled
     let tls_acceptor = if settings.tls_enabled {
         let certs = {
-            let cert_file = File::open(&settings.tls_cert_path)
-                .map_err(|e| format!("Failed to open cert file {}: {}", settings.tls_cert_path, e))?;
+            let cert_file = File::open(&settings.tls_cert_path).map_err(|e| {
+                format!("Failed to open cert file {}: {}", settings.tls_cert_path, e)
+            })?;
             let mut cert_reader = std::io::BufReader::new(cert_file);
             certs(&mut cert_reader)
                 .collect::<Result<Vec<_>, _>>()
@@ -247,6 +251,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         decoding_key: Arc::new(decoding_key),
     };
 
+    // OIDC provider configuration (issuer, JWKS, registered clients).
+    let oidc_config = Arc::new(
+        OidcConfig::from_env(&settings.decoding_key_path)
+            .map_err(|e| format!("Failed to load OIDC configuration: {}", e))?,
+    );
+    let oidc_code_store = AuthorizationCodeStore::new();
+    let apple_jwks_cache = Arc::new(AppleJwksCache::new());
+
     let session_store = MemoryStore::default();
     let session_service = ServiceBuilder::new().layer(
         SessionManagerLayer::new(session_store)
@@ -265,6 +277,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             "/.well-known/apple-app-site-association",
             get(serve_apple_app_site_association),
         )
+        // OIDC discovery + JWKS (advertise this server as an OIDC provider)
+        .route("/.well-known/openid-configuration", get(oidc_discovery))
+        .route("/.well-known/jwks.json", get(oidc_jwks))
+        // OIDC endpoints
+        .route("/oauth/authorize", get(oidc_authorize))
+        .route("/oauth/token", post(oidc_token))
+        .route("/oauth/userinfo", get(oidc_userinfo))
+        // Sign in with Apple
+        .route("/oauth/apple/idtoken", post(apple_idtoken_handler))
+        .route("/oauth/apple/callback", post(apple_callback_handler))
+        // Existing OAuth callback for native-app deep links (Patreon/Twitch/Discord/Reddit)
         .route("/oauth/:client/:provider", get(handle_oauth_callback))
         .route("/register/:username", get(start_register))
         .route("/register", post(finish_register))
@@ -279,6 +302,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         )
         .route("/device-check/assert", post(finish_assertion))
         .layer(Extension(app_state))
+        .layer(Extension(oidc_config))
+        .layer(Extension(oidc_code_store))
+        .layer(Extension(apple_jwks_cache))
         .layer(session_service)
         .layer(Extension(apple_app_site_association))
         .fallback(handler_fallback);
@@ -311,13 +337,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
 
         // HTTP/2 server on TCP
-        let listener = tokio::net::TcpListener::bind(&addr).await
+        let listener = tokio::net::TcpListener::bind(&addr)
+            .await
             .map_err(|e| format!("Failed to bind to {}: {}", addr, e))?;
 
         let make_service = app.into_make_service();
 
         loop {
-            let (stream, remote_addr) = listener.accept().await
+            let (stream, remote_addr) = listener
+                .accept()
+                .await
                 .map_err(|e| format!("Failed to accept connection: {}", e))?;
 
             let tls_acceptor = tls_acceptor.clone();
@@ -334,13 +363,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                             }
                         };
 
-                        let hyper_service = hyper::service::service_fn(move |request: hyper::Request<hyper::body::Incoming>| {
-                            tower_service.clone().call(request)
-                        });
+                        let hyper_service = hyper::service::service_fn(
+                            move |request: hyper::Request<hyper::body::Incoming>| {
+                                tower_service.clone().call(request)
+                            },
+                        );
 
-                        if let Err(err) = hyper_util::server::conn::auto::Builder::new(hyper_util::rt::TokioExecutor::new())
-                            .serve_connection(hyper_util::rt::TokioIo::new(tls_stream), hyper_service)
-                            .await
+                        if let Err(err) = hyper_util::server::conn::auto::Builder::new(
+                            hyper_util::rt::TokioExecutor::new(),
+                        )
+                        .serve_connection(hyper_util::rt::TokioIo::new(tls_stream), hyper_service)
+                        .await
                         {
                             eprintln!("Error serving connection: {:?}", err);
                         }
@@ -353,10 +386,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     } else {
         // HTTP mode without TLS
-        let listener = tokio::net::TcpListener::bind(&addr).await
+        let listener = tokio::net::TcpListener::bind(&addr)
+            .await
             .map_err(|e| format!("Failed to bind to {}: {}", addr, e))?;
 
-        axum::serve(listener, app).await
+        axum::serve(listener, app)
+            .await
             .map_err(|e| format!("Server error: {}", e))?;
     }
 
@@ -505,8 +540,8 @@ fn load_single_ec_key(key_path: &str) -> Result<SigningKey<NistP256>, Box<dyn st
     Ok(SigningKey::from(secret_key))
 }
 
-async fn load_apple_app_site_association(
-) -> Result<Arc<RwLock<serde_json::Value>>, Box<dyn std::error::Error>> {
+async fn load_apple_app_site_association()
+-> Result<Arc<RwLock<serde_json::Value>>, Box<dyn std::error::Error>> {
     let content = tokio::fs::read_to_string("apple-app-site-association.json")
         .await
         .map_err(|e| format!("Failed to read apple-app-site-association.json: {}", e))?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use std::sync::Arc;
 use axum::extract::Request;
 use axum::http::{Method, StatusCode};
 use axum::response::{IntoResponse, Redirect, Response};
-use axum::routing::{get, head, post};
+use axum::routing::{get, post};
 use axum::{Extension, Router};
 use ecdsa::SigningKey;
 use http::Uri;
@@ -698,11 +698,11 @@ async fn handle_oauth_callback(
     let params: HashMap<_, _> = form_urlencoded::parse(query.as_bytes()).collect();
 
     // Validate state parameter if provider requires it
-    if let Some(state) = params.get("state") {
-        if !validate_oauth_state(state) {
-            error!("Invalid OAuth state parameter for {:?}", provider);
-            return Redirect::temporary(&provider.get_error_uri("invalid_state", client));
-        }
+    if let Some(state) = params.get("state")
+        && !validate_oauth_state(state)
+    {
+        error!("Invalid OAuth state parameter for {:?}", provider);
+        return Redirect::temporary(&provider.get_error_uri("invalid_state", client));
     }
 
     // Handle the authorization code

--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -292,7 +292,7 @@ pub async fn discovery(Extension(oidc): Extension<Arc<OidcConfig>>) -> impl Into
         response_types_supported: vec!["code"],
         subject_types_supported: vec!["public"],
         id_token_signing_alg_values_supported: vec!["ES256"],
-        scopes_supported: vec!["openid", "email", "profile", "offline_access"],
+        scopes_supported: vec!["openid", "email", "profile"],
         token_endpoint_auth_methods_supported: vec![
             "client_secret_post",
             "client_secret_basic",

--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -731,6 +731,11 @@ pub enum AuthorizeError {
     InvalidArkavoJwt(String),
     #[error("invalid Apple id_token: {0}")]
     InvalidAppleIdToken(String),
+    #[error(
+        "idp=apple requires the OIDC `nonce` query parameter (used as the Apple nonce). \
+         No nonce was supplied — refusing to validate Apple id_token."
+    )]
+    AppleNonceRequired,
     #[error("apple_signin error: {0}")]
     AppleSigninError(#[from] apple_signin::AppleSigninError),
     #[error("database error: {0}")]
@@ -744,6 +749,7 @@ impl IntoResponse for AuthorizeError {
             AuthorizeError::InvalidArkavoJwt(_) | AuthorizeError::InvalidAppleIdToken(_) => {
                 (StatusCode::UNAUTHORIZED, "invalid_token")
             }
+            AuthorizeError::AppleNonceRequired => (StatusCode::BAD_REQUEST, "invalid_request"),
             AuthorizeError::AppleSigninError(_) => (StatusCode::UNAUTHORIZED, "invalid_token"),
             AuthorizeError::Database(_) => (StatusCode::INTERNAL_SERVER_ERROR, "server_error"),
         };
@@ -775,7 +781,20 @@ async fn resolve_user(
                 AuthorizeError::InvalidAppleIdToken("id_token is required for idp=apple".into())
             })?;
 
-        let apple_claims = apple_signin::verify_apple_id_token(apple, &token).await?;
+        // For the authorize flow the OIDC `nonce` query parameter doubles as
+        // the Apple nonce: the client uses the same value when invoking Apple
+        // Sign In, Apple echoes it in the id_token, and we verify the match.
+        // We refuse to validate Apple tokens without a nonce — this is the
+        // mandatory anti-replay binding for the upstream Apple ceremony.
+        let nonce = params
+            .nonce
+            .as_deref()
+            .ok_or(AuthorizeError::AppleNonceRequired)?;
+        if nonce.is_empty() {
+            return Err(AuthorizeError::AppleNonceRequired);
+        }
+
+        let apple_claims = apple_signin::verify_apple_id_token(apple, &token, nonce).await?;
         return apple_signin::map_apple_user(app_state, &apple_claims)
             .await
             .map_err(|e| AuthorizeError::Database(e.to_string()));
@@ -951,6 +970,12 @@ mod tests {
         let a = test_jwk();
         let b = test_jwk();
         assert_eq!(a.kid, b.kid);
+    }
+
+    #[test]
+    fn test_authorize_error_apple_nonce_required_is_400() {
+        let resp = AuthorizeError::AppleNonceRequired.into_response();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
     }
 
     #[test]

--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -30,6 +30,7 @@ use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Redirect, Response};
 use base64::Engine;
 use chrono::Utc;
+use fred::interfaces::{ClientLike, KeysInterface};
 use jsonwebtoken::{Algorithm, DecodingKey, Header, Validation, decode, encode};
 use log::{debug, error, info, warn};
 use p256::PublicKey;
@@ -123,7 +124,7 @@ pub struct OidcClaims {
 }
 
 /// Information about an authenticated user used to mint OIDC tokens.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AuthenticatedUser {
     /// Stable subject identifier used in the `sub` claim.
     /// Format: `apple:<apple_sub>` or `arkavo:<uuid>` so it's clear which IdP issued.
@@ -139,9 +140,9 @@ pub struct AuthenticatedUser {
 }
 
 /// Stored authorization code metadata, keyed by the random code value.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[allow(dead_code)]
-struct AuthorizationCodeRecord {
+pub struct AuthorizationCodeRecord {
     client_id: String,
     redirect_uri: String,
     scope: String,
@@ -154,35 +155,193 @@ struct AuthorizationCodeRecord {
     expires_at: i64,
 }
 
-/// In-memory authorization code store.
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct RefreshTokenRecord {
+    pub subject: String,
+    pub client_id: String,
+    pub scopes: String,
+    pub expires_at: i64,
+    pub created_at: i64,
+}
+
+/// Redis-backed (with local in-memory fallback) authorization code store.
 ///
 /// Authorization codes are short-lived (10 minutes) and single-use.
-/// For multi-instance deployments this should be replaced with a shared store.
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct AuthorizationCodeStore {
-    inner: Arc<Mutex<HashMap<String, AuthorizationCodeRecord>>>,
+    redis: fred::clients::RedisClient,
+    local_fallback: Arc<Mutex<HashMap<String, AuthorizationCodeRecord>>>,
 }
 
 impl AuthorizationCodeStore {
-    pub fn new() -> Self {
-        Self::default()
-    }
-
-    fn insert(&self, code: String, record: AuthorizationCodeRecord) {
-        let mut map = self.inner.lock().unwrap();
-        // Best-effort cleanup of expired codes on each insert.
-        let now = Utc::now().timestamp();
-        map.retain(|_, v| v.expires_at > now);
-        map.insert(code, record);
-    }
-
-    fn take(&self, code: &str) -> Option<AuthorizationCodeRecord> {
-        let mut map = self.inner.lock().unwrap();
-        let record = map.remove(code)?;
-        if record.expires_at < Utc::now().timestamp() {
-            return None;
+    pub fn new(redis: fred::clients::RedisClient) -> Self {
+        Self {
+            redis,
+            local_fallback: Arc::new(Mutex::new(HashMap::new())),
         }
-        Some(record)
+    }
+
+    pub async fn insert(
+        &self,
+        code: String,
+        record: AuthorizationCodeRecord,
+    ) -> Result<(), String> {
+        let key = format!("oidc:code:{}", code);
+        if self.redis.is_connected() {
+            let value = serde_json::to_string(&record)
+                .map_err(|e| format!("Serialization failed: {}", e))?;
+            let _: () = self
+                .redis
+                .set(
+                    &key,
+                    value,
+                    Some(fred::types::Expiration::EX(600)),
+                    None,
+                    false,
+                )
+                .await
+                .map_err(|e| format!("Redis set failed: {}", e))?;
+            Ok(())
+        } else {
+            log::warn!("Redis is offline; falling back to in-memory AuthorizationCodeStore");
+            let mut map = self.local_fallback.lock().unwrap();
+            let now = Utc::now().timestamp();
+            map.retain(|_, v| v.expires_at > now);
+            map.insert(code, record);
+            Ok(())
+        }
+    }
+
+    pub async fn take(&self, code: &str) -> Result<Option<AuthorizationCodeRecord>, String> {
+        let key = format!("oidc:code:{}", code);
+        if self.redis.is_connected() {
+            let val: Option<String> = self
+                .redis
+                .get(&key)
+                .await
+                .map_err(|e| format!("Redis get failed: {}", e))?;
+            if let Some(json_str) = val {
+                // Delete immediately on retrieval (single-use)
+                let _: () = self
+                    .redis
+                    .del(&key)
+                    .await
+                    .map_err(|e| format!("Redis del failed: {}", e))?;
+                let record: AuthorizationCodeRecord = serde_json::from_str(&json_str)
+                    .map_err(|e| format!("Deserialization failed: {}", e))?;
+                if record.expires_at < Utc::now().timestamp() {
+                    return Ok(None);
+                }
+                Ok(Some(record))
+            } else {
+                Ok(None)
+            }
+        } else {
+            log::warn!("Redis is offline; falling back to in-memory AuthorizationCodeStore");
+            let mut map = self.local_fallback.lock().unwrap();
+            if let Some(record) = map.remove(code) {
+                if record.expires_at < Utc::now().timestamp() {
+                    return Ok(None);
+                }
+                Ok(Some(record))
+            } else {
+                Ok(None)
+            }
+        }
+    }
+}
+
+/// Redis-backed (with local in-memory fallback) refresh token store.
+///
+/// Stores SHA-256 hash of refresh tokens with 30-day automatic expiration.
+#[derive(Clone)]
+pub struct RefreshTokenStore {
+    redis: fred::clients::RedisClient,
+    local_fallback: Arc<Mutex<HashMap<String, RefreshTokenRecord>>>,
+}
+
+impl RefreshTokenStore {
+    pub fn new(redis: fred::clients::RedisClient) -> Self {
+        Self {
+            redis,
+            local_fallback: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    fn hash_token(&self, token: &str) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(token.as_bytes());
+        hex::encode(hasher.finalize())
+    }
+
+    pub async fn insert(&self, token: &str, record: RefreshTokenRecord) -> Result<(), String> {
+        let token_hash = self.hash_token(token);
+        let key = format!("oidc:refresh:{}", token_hash);
+        let ttl_seconds = crate::constants::REFRESH_TOKEN_LIFETIME_SECONDS;
+
+        if self.redis.is_connected() {
+            let value = serde_json::to_string(&record)
+                .map_err(|e| format!("Serialization failed: {}", e))?;
+            let _: () = self
+                .redis
+                .set(
+                    &key,
+                    value,
+                    Some(fred::types::Expiration::EX(ttl_seconds)),
+                    None,
+                    false,
+                )
+                .await
+                .map_err(|e| format!("Redis set failed: {}", e))?;
+            Ok(())
+        } else {
+            log::warn!("Redis is offline; falling back to in-memory RefreshTokenStore");
+            let mut map = self.local_fallback.lock().unwrap();
+            let now = Utc::now().timestamp();
+            map.retain(|_, v| v.expires_at > now);
+            map.insert(token_hash, record);
+            Ok(())
+        }
+    }
+
+    pub async fn take(&self, token: &str) -> Result<Option<RefreshTokenRecord>, String> {
+        let token_hash = self.hash_token(token);
+        let key = format!("oidc:refresh:{}", token_hash);
+
+        if self.redis.is_connected() {
+            let val: Option<String> = self
+                .redis
+                .get(&key)
+                .await
+                .map_err(|e| format!("Redis get failed: {}", e))?;
+            if let Some(json_str) = val {
+                // Delete immediately on retrieval (Refresh Token Rotation)
+                let _: () = self
+                    .redis
+                    .del(&key)
+                    .await
+                    .map_err(|e| format!("Redis del failed: {}", e))?;
+                let record: RefreshTokenRecord = serde_json::from_str(&json_str)
+                    .map_err(|e| format!("Deserialization failed: {}", e))?;
+                if record.expires_at < Utc::now().timestamp() {
+                    return Ok(None);
+                }
+                Ok(Some(record))
+            } else {
+                Ok(None)
+            }
+        } else {
+            log::warn!("Redis is offline; falling back to in-memory RefreshTokenStore");
+            let mut map = self.local_fallback.lock().unwrap();
+            if let Some(record) = map.remove(&token_hash) {
+                if record.expires_at < Utc::now().timestamp() {
+                    return Ok(None);
+                }
+                Ok(Some(record))
+            } else {
+                Ok(None)
+            }
+        }
     }
 }
 
@@ -292,7 +451,7 @@ pub async fn discovery(Extension(oidc): Extension<Arc<OidcConfig>>) -> impl Into
         response_types_supported: vec!["code"],
         subject_types_supported: vec!["public"],
         id_token_signing_alg_values_supported: vec!["ES256"],
-        scopes_supported: vec!["openid", "email", "profile"],
+        scopes_supported: vec!["openid", "email", "profile", "offline_access"],
         token_endpoint_auth_methods_supported: vec![
             "client_secret_post",
             "client_secret_basic",
@@ -312,7 +471,7 @@ pub async fn discovery(Extension(oidc): Extension<Arc<OidcConfig>>) -> impl Into
             "arkavo_roles",
             "arkavo_entitlements",
         ],
-        grant_types_supported: vec!["authorization_code"],
+        grant_types_supported: vec!["authorization_code", "client_credentials", "refresh_token"],
         code_challenge_methods_supported: vec!["S256"],
     };
     Json(doc)
@@ -425,19 +584,29 @@ pub async fn authorize(
     // Mint an authorization code.
     let code = generate_authz_code();
     let expires_at = Utc::now().timestamp() + AUTHORIZATION_CODE_LIFETIME_SECONDS;
-    code_store.insert(
-        code.clone(),
-        AuthorizationCodeRecord {
-            client_id: client.client_id.clone(),
-            redirect_uri: params.redirect_uri.clone(),
-            scope,
-            nonce: params.nonce.clone(),
-            code_challenge: params.code_challenge.clone(),
-            code_challenge_method: params.code_challenge_method.clone(),
-            user,
-            expires_at,
-        },
-    );
+    if let Err(err) = code_store
+        .insert(
+            code.clone(),
+            AuthorizationCodeRecord {
+                client_id: client.client_id.clone(),
+                redirect_uri: params.redirect_uri.clone(),
+                scope,
+                nonce: params.nonce.clone(),
+                code_challenge: params.code_challenge.clone(),
+                code_challenge_method: params.code_challenge_method.clone(),
+                user,
+                expires_at,
+            },
+        )
+        .await
+    {
+        error!("Failed to store authorization code: {}", err);
+        return oidc_error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "server_error",
+            "Internal server error",
+        );
+    }
 
     // Redirect back to the relying party with code + state.
     let mut redirect = format!("{}?code={}", params.redirect_uri, code);
@@ -457,6 +626,8 @@ pub struct TokenForm {
     pub client_id: Option<String>,
     pub client_secret: Option<String>,
     pub code_verifier: Option<String>,
+    pub refresh_token: Option<String>,
+    pub scope: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -466,24 +637,53 @@ pub struct TokenResponse {
     pub expires_in: i64,
     pub id_token: String,
     pub scope: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub refresh_token: Option<String>,
 }
 
-/// Token endpoint: exchanges an authorization code for tokens.
+/// Token endpoint: exchanges an authorization code, client credentials, or refresh token for tokens.
 pub async fn token(
     Extension(app_state): Extension<AppState>,
     Extension(oidc): Extension<Arc<OidcConfig>>,
     Extension(code_store): Extension<AuthorizationCodeStore>,
+    Extension(refresh_store): Extension<RefreshTokenStore>,
     headers: HeaderMap,
     Form(form): Form<TokenForm>,
 ) -> Response {
-    if form.grant_type != "authorization_code" {
-        return oidc_error_response(
+    match form.grant_type.as_str() {
+        "authorization_code" => {
+            handle_authorization_code_grant(
+                app_state,
+                oidc,
+                code_store,
+                refresh_store,
+                headers,
+                form,
+            )
+            .await
+        }
+        "client_credentials" => {
+            handle_client_credentials_grant(app_state, oidc, headers, form).await
+        }
+        "refresh_token" => {
+            handle_refresh_token_grant(app_state, oidc, refresh_store, headers, form).await
+        }
+        _ => oidc_error_response(
             StatusCode::BAD_REQUEST,
             "unsupported_grant_type",
-            "Only authorization_code is supported",
-        );
+            "Unsupported grant_type. Supported: authorization_code, client_credentials, refresh_token",
+        ),
     }
+}
 
+async fn handle_authorization_code_grant(
+    app_state: AppState,
+    oidc: Arc<OidcConfig>,
+    code_store: AuthorizationCodeStore,
+    refresh_store: RefreshTokenStore,
+    headers: HeaderMap,
+    form: TokenForm,
+) -> Response {
     let code = match form.code.as_deref() {
         Some(c) if !c.is_empty() => c,
         _ => {
@@ -495,9 +695,9 @@ pub async fn token(
         }
     };
 
-    let record = match code_store.take(code) {
-        Some(r) => r,
-        None => {
+    let record = match code_store.take(code).await {
+        Ok(Some(r)) => r,
+        _ => {
             return oidc_error_response(
                 StatusCode::BAD_REQUEST,
                 "invalid_grant",
@@ -638,9 +838,39 @@ pub async fn token(
         }
     };
 
+    // Issue standard refresh token if offline_access is requested
+    let mut refresh_token = None;
+    if record
+        .scope
+        .split_whitespace()
+        .any(|s| s == "offline_access")
+    {
+        let r_token = generate_refresh_token();
+        let expires_at = now + crate::constants::REFRESH_TOKEN_LIFETIME_SECONDS;
+        let refresh_record = RefreshTokenRecord {
+            subject: record.user.subject.clone(),
+            client_id: record.client_id.clone(),
+            scopes: record.scope.clone(),
+            expires_at,
+            created_at: now,
+        };
+        if let Err(err) = refresh_store.insert(&r_token, refresh_record).await {
+            error!("Failed to store refresh token: {}", err);
+            return oidc_error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "server_error",
+                "Failed to issue refresh token",
+            );
+        }
+        refresh_token = Some(r_token);
+    }
+
     info!(
-        "Issued OIDC tokens for client={} sub={} idp={}",
-        record.client_id, record.user.subject, record.user.idp
+        "Issued OIDC tokens for client={} sub={} idp={} (refresh={})",
+        record.client_id,
+        record.user.subject,
+        record.user.idp,
+        refresh_token.is_some()
     );
 
     let mut response = Json(TokenResponse {
@@ -649,6 +879,7 @@ pub async fn token(
         expires_in: ACCESS_TOKEN_LIFETIME_SECONDS,
         id_token,
         scope: record.scope,
+        refresh_token,
     })
     .into_response();
     // OAuth2 requires Cache-Control: no-store and Pragma: no-cache on token responses.
@@ -661,6 +892,326 @@ pub async fn token(
         axum::http::HeaderValue::from_static("no-cache"),
     );
     response
+}
+
+async fn handle_client_credentials_grant(
+    app_state: AppState,
+    oidc: Arc<OidcConfig>,
+    headers: HeaderMap,
+    form: TokenForm,
+) -> Response {
+    let (presented_client_id, presented_client_secret) =
+        extract_client_credentials(&headers, &form);
+    let presented_client_id = match presented_client_id {
+        Some(id) => id,
+        None => {
+            return oidc_error_response(
+                StatusCode::BAD_REQUEST,
+                "invalid_request",
+                "client_id is required",
+            );
+        }
+    };
+
+    let client = match oidc.clients.get(&presented_client_id) {
+        Some(c) => c,
+        None => {
+            return oidc_error_response(
+                StatusCode::BAD_REQUEST,
+                "invalid_client",
+                "Unknown client_id",
+            );
+        }
+    };
+
+    match (&client.client_secret, &presented_client_secret) {
+        (Some(expected), Some(given)) if constant_time_eq(expected, given) => {}
+        _ => {
+            return oidc_error_response(
+                StatusCode::UNAUTHORIZED,
+                "invalid_client",
+                "Invalid client credentials",
+            );
+        }
+    }
+
+    let now = Utc::now().timestamp();
+    let exp = now + ACCESS_TOKEN_LIFETIME_SECONDS;
+    let client_subject = format!("client:{}", client.client_id);
+    let scope = form.scope.unwrap_or_else(|| "openid".to_string());
+
+    let id_claims = OidcClaims {
+        iss: oidc.issuer.clone(),
+        sub: client_subject.clone(),
+        aud: client.client_id.clone(),
+        exp,
+        iat: now,
+        nonce: None,
+        email: None,
+        email_verified: None,
+        idp: "client_credentials".to_string(),
+        arkavo_account_id: client_subject.clone(),
+        arkavo_roles: vec!["service-account".to_string()],
+        // Grant standard entitlements so service accounts can encrypt/decrypt OpenTDF payloads
+        arkavo_entitlements: vec!["tdf:create".to_string(), "tdf:decrypt".to_string()],
+    };
+
+    let mut header = Header::new(Algorithm::ES256);
+    header.kid = Some(oidc.signing_kid.clone());
+
+    let id_token = match encode(&header, &id_claims, &app_state.encoding_key) {
+        Ok(t) => t,
+        Err(e) => {
+            error!("Failed to encode id_token: {}", e);
+            return oidc_error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "server_error",
+                "Failed to issue id_token",
+            );
+        }
+    };
+    let access_token = match encode(&header, &id_claims, &app_state.encoding_key) {
+        Ok(t) => t,
+        Err(e) => {
+            error!("Failed to encode access_token: {}", e);
+            return oidc_error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "server_error",
+                "Failed to issue access_token",
+            );
+        }
+    };
+
+    info!(
+        "Issued OIDC client credentials tokens for client_id={}",
+        client.client_id
+    );
+
+    let mut response = Json(TokenResponse {
+        access_token,
+        token_type: "Bearer".to_string(),
+        expires_in: ACCESS_TOKEN_LIFETIME_SECONDS,
+        id_token,
+        scope,
+        refresh_token: None,
+    })
+    .into_response();
+    response.headers_mut().insert(
+        axum::http::header::CACHE_CONTROL,
+        axum::http::HeaderValue::from_static("no-store"),
+    );
+    response.headers_mut().insert(
+        axum::http::header::PRAGMA,
+        axum::http::HeaderValue::from_static("no-cache"),
+    );
+    response
+}
+
+async fn handle_refresh_token_grant(
+    app_state: AppState,
+    oidc: Arc<OidcConfig>,
+    refresh_store: RefreshTokenStore,
+    headers: HeaderMap,
+    form: TokenForm,
+) -> Response {
+    let r_token = match form.refresh_token.as_deref() {
+        Some(t) if !t.is_empty() => t,
+        _ => {
+            return oidc_error_response(
+                StatusCode::BAD_REQUEST,
+                "invalid_request",
+                "refresh_token is required",
+            );
+        }
+    };
+
+    // Authenticate the client (if client_secret exists, must authenticate)
+    let (presented_client_id, presented_client_secret) =
+        extract_client_credentials(&headers, &form);
+    let presented_client_id = match presented_client_id {
+        Some(id) => id,
+        None => {
+            return oidc_error_response(
+                StatusCode::BAD_REQUEST,
+                "invalid_request",
+                "client_id is required",
+            );
+        }
+    };
+
+    let client = match oidc.clients.get(&presented_client_id) {
+        Some(c) => c,
+        None => {
+            return oidc_error_response(
+                StatusCode::BAD_REQUEST,
+                "invalid_client",
+                "Unknown client_id",
+            );
+        }
+    };
+
+    if let Some(expected_secret) = &client.client_secret {
+        match &presented_client_secret {
+            Some(given) if constant_time_eq(expected_secret, given) => {}
+            _ => {
+                return oidc_error_response(
+                    StatusCode::UNAUTHORIZED,
+                    "invalid_client",
+                    "Invalid client credentials",
+                );
+            }
+        }
+    }
+
+    // Retrieve and rotate (delete) token from Redis
+    let record = match refresh_store.take(r_token).await {
+        Ok(Some(rec)) => rec,
+        _ => {
+            return oidc_error_response(
+                StatusCode::BAD_REQUEST,
+                "invalid_grant",
+                "Invalid, expired, or rotated refresh token",
+            );
+        }
+    };
+
+    if record.client_id != presented_client_id {
+        return oidc_error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_grant",
+            "Client ID mismatch",
+        );
+    }
+
+    let now = Utc::now().timestamp();
+    if record.expires_at < now {
+        return oidc_error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_grant",
+            "Refresh token has expired",
+        );
+    }
+
+    // Resolve standard roles and entitlements based on subject pattern
+    let (roles, entitlements, idp) = if record.subject.starts_with("client:") {
+        (
+            vec!["service-account".to_string()],
+            vec!["tdf:create".to_string(), "tdf:decrypt".to_string()],
+            "client_credentials".to_string(),
+        )
+    } else {
+        let auth_idp = if record.subject.starts_with("apple:") {
+            "apple"
+        } else {
+            "webauthn"
+        };
+        (
+            vec!["user".to_string()],
+            vec!["tdf:create".to_string(), "tdf:decrypt".to_string()],
+            auth_idp.to_string(),
+        )
+    };
+
+    let id_exp = now + ID_TOKEN_LIFETIME_SECONDS;
+    let at_exp = now + ACCESS_TOKEN_LIFETIME_SECONDS;
+
+    let id_claims = OidcClaims {
+        iss: oidc.issuer.clone(),
+        sub: record.subject.clone(),
+        aud: record.client_id.clone(),
+        exp: id_exp,
+        iat: now,
+        nonce: None,
+        email: None,
+        email_verified: None,
+        idp,
+        arkavo_account_id: record.subject.clone(),
+        arkavo_roles: roles,
+        arkavo_entitlements: entitlements,
+    };
+    let mut access_claims = id_claims.clone();
+    access_claims.exp = at_exp;
+
+    let mut header = Header::new(Algorithm::ES256);
+    header.kid = Some(oidc.signing_kid.clone());
+
+    let id_token = match encode(&header, &id_claims, &app_state.encoding_key) {
+        Ok(t) => t,
+        Err(e) => {
+            error!("Failed to encode id_token: {}", e);
+            return oidc_error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "server_error",
+                "Failed to issue id_token",
+            );
+        }
+    };
+    let access_token = match encode(&header, &access_claims, &app_state.encoding_key) {
+        Ok(t) => t,
+        Err(e) => {
+            error!("Failed to encode access_token: {}", e);
+            return oidc_error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "server_error",
+                "Failed to issue access_token",
+            );
+        }
+    };
+
+    // Rotate refresh token (issue a brand new one)
+    let new_refresh_token = generate_refresh_token();
+    let expires_at = now + crate::constants::REFRESH_TOKEN_LIFETIME_SECONDS;
+    let new_refresh_record = RefreshTokenRecord {
+        subject: record.subject.clone(),
+        client_id: record.client_id.clone(),
+        scopes: record.scopes.clone(),
+        expires_at,
+        created_at: now,
+    };
+    if let Err(err) = refresh_store
+        .insert(&new_refresh_token, new_refresh_record)
+        .await
+    {
+        error!("Failed to store rotated refresh token: {}", err);
+        return oidc_error_response(
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "server_error",
+            "Failed to issue rotated refresh token",
+        );
+    }
+
+    info!(
+        "Rotated OIDC refresh tokens for client_id={} sub={}",
+        record.client_id, record.subject
+    );
+
+    let mut response = Json(TokenResponse {
+        access_token,
+        token_type: "Bearer".to_string(),
+        expires_in: ACCESS_TOKEN_LIFETIME_SECONDS,
+        id_token,
+        scope: record.scopes,
+        refresh_token: Some(new_refresh_token),
+    })
+    .into_response();
+    response.headers_mut().insert(
+        axum::http::header::CACHE_CONTROL,
+        axum::http::HeaderValue::from_static("no-store"),
+    );
+    response.headers_mut().insert(
+        axum::http::header::PRAGMA,
+        axum::http::HeaderValue::from_static("no-cache"),
+    );
+    response
+}
+
+fn generate_refresh_token() -> String {
+    let part1 = Uuid::new_v4();
+    let part2 = Uuid::new_v4();
+    let mut bytes = Vec::with_capacity(32);
+    bytes.extend_from_slice(part1.as_bytes());
+    bytes.extend_from_slice(part2.as_bytes());
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
 }
 
 #[derive(Debug, Serialize)]
@@ -1003,9 +1554,14 @@ mod tests {
         assert!(a.len() >= 40, "authz code too short: {}", a.len());
     }
 
-    #[test]
-    fn test_authorization_code_store_roundtrip() {
-        let store = AuthorizationCodeStore::new();
+    fn test_redis() -> fred::clients::RedisClient {
+        let config = fred::types::RedisConfig::default();
+        fred::clients::RedisClient::new(config, None, None, None)
+    }
+
+    #[tokio::test]
+    async fn test_authorization_code_store_roundtrip() {
+        let store = AuthorizationCodeStore::new(test_redis());
         let code = "abc".to_string();
         let user = AuthenticatedUser {
             subject: "apple:123".into(),
@@ -1026,15 +1582,15 @@ mod tests {
             user,
             expires_at: Utc::now().timestamp() + 60,
         };
-        store.insert(code.clone(), record);
-        assert!(store.take(&code).is_some());
+        store.insert(code.clone(), record).await.unwrap();
+        assert!(store.take(&code).await.unwrap().is_some());
         // single-use: second take returns None
-        assert!(store.take(&code).is_none());
+        assert!(store.take(&code).await.unwrap().is_none());
     }
 
-    #[test]
-    fn test_authorization_code_store_expired_take_returns_none() {
-        let store = AuthorizationCodeStore::new();
+    #[tokio::test]
+    async fn test_authorization_code_store_expired_take_returns_none() {
+        let store = AuthorizationCodeStore::new(test_redis());
         let code = "expired".to_string();
         let user = AuthenticatedUser {
             subject: "apple:123".into(),
@@ -1055,8 +1611,27 @@ mod tests {
             user,
             expires_at: Utc::now().timestamp() - 1,
         };
-        store.insert(code.clone(), record);
-        assert!(store.take(&code).is_none());
+        store.insert(code.clone(), record).await.unwrap();
+        assert!(store.take(&code).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_refresh_token_store_roundtrip() {
+        let store = RefreshTokenStore::new(test_redis());
+        let token = "some-secure-token-value-123456789";
+        let record = RefreshTokenRecord {
+            subject: "client:opentdf".into(),
+            client_id: "opentdf".into(),
+            scopes: "openid offline_access".into(),
+            expires_at: Utc::now().timestamp() + 600,
+            created_at: Utc::now().timestamp(),
+        };
+        store.insert(token, record).await.unwrap();
+        let taken = store.take(token).await.unwrap();
+        assert!(taken.is_some());
+        assert_eq!(taken.unwrap().client_id, "opentdf");
+        // rotated/single-use: second take returns None
+        assert!(store.take(token).await.unwrap().is_none());
     }
 
     #[tokio::test]
@@ -1174,5 +1749,164 @@ mod tests {
         assert!(json.contains("arkavo_account_id"));
         assert!(json.contains("arkavo_roles"));
         assert!(json.contains("arkavo_entitlements"));
+    }
+
+    #[tokio::test]
+    async fn test_client_credentials_grant() {
+        use p256::pkcs8::EncodePrivateKey;
+        unsafe {
+            std::env::set_var("AWS_REGION", "us-east-1");
+            std::env::set_var("AWS_ACCESS_KEY_ID", "fake_access_key");
+            std::env::set_var("AWS_SECRET_ACCESS_KEY", "fake_secret_key");
+        }
+        let scalar = p256::elliptic_curve::ScalarPrimitive::from_slice(&[0x42u8; 32]).unwrap();
+        let secret = SecretKey::new(scalar);
+        let der = secret.to_pkcs8_der().unwrap();
+        let encoding_key = jsonwebtoken::EncodingKey::from_ec_der(der.as_bytes());
+
+        let app_state = AppState {
+            webauthn: Arc::new(
+                webauthn_rs::WebauthnBuilder::new(
+                    "identity.arkavo.net",
+                    &url::Url::parse("https://identity.arkavo.net").unwrap(),
+                )
+                .unwrap()
+                .build()
+                .unwrap(),
+            ),
+            db_store: Arc::new(
+                crate::db::DynamoDBStore::new(
+                    "credentials".to_string(),
+                    "handles".to_string(),
+                    "device_bindings".to_string(),
+                )
+                .await
+                .unwrap(),
+            ),
+            signing_key: Arc::new(p256::ecdsa::SigningKey::from(&secret)),
+            encoding_key: Arc::new(encoding_key),
+            decoding_key: Arc::new(jsonwebtoken::DecodingKey::from_secret(&[])),
+        };
+
+        let mut oidc = (*test_oidc_config()).clone();
+        oidc.clients.insert(
+            "test-client".to_string(),
+            OidcClient {
+                client_id: "test-client".to_string(),
+                client_secret: Some("test-secret".to_string()),
+                redirect_uris: vec![],
+            },
+        );
+        let oidc = Arc::new(oidc);
+
+        let form = TokenForm {
+            grant_type: "client_credentials".to_string(),
+            code: None,
+            redirect_uri: None,
+            client_id: Some("test-client".to_string()),
+            client_secret: Some("test-secret".to_string()),
+            code_verifier: None,
+            refresh_token: None,
+            scope: None,
+        };
+
+        let headers = HeaderMap::new();
+        let resp = handle_client_credentials_grant(app_state, oidc, headers, form).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body_bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+        assert!(!body["access_token"].as_str().unwrap().is_empty());
+        assert!(!body["id_token"].as_str().unwrap().is_empty());
+        assert_eq!(body["scope"].as_str().unwrap(), "openid");
+    }
+
+    #[tokio::test]
+    async fn test_refresh_token_grant() {
+        use p256::pkcs8::EncodePrivateKey;
+        unsafe {
+            std::env::set_var("AWS_REGION", "us-east-1");
+            std::env::set_var("AWS_ACCESS_KEY_ID", "fake_access_key");
+            std::env::set_var("AWS_SECRET_ACCESS_KEY", "fake_secret_key");
+        }
+        let scalar = p256::elliptic_curve::ScalarPrimitive::from_slice(&[0x42u8; 32]).unwrap();
+        let secret = SecretKey::new(scalar);
+        let der = secret.to_pkcs8_der().unwrap();
+        let encoding_key = jsonwebtoken::EncodingKey::from_ec_der(der.as_bytes());
+
+        let app_state = AppState {
+            webauthn: Arc::new(
+                webauthn_rs::WebauthnBuilder::new(
+                    "identity.arkavo.net",
+                    &url::Url::parse("https://identity.arkavo.net").unwrap(),
+                )
+                .unwrap()
+                .build()
+                .unwrap(),
+            ),
+            db_store: Arc::new(
+                crate::db::DynamoDBStore::new(
+                    "credentials".to_string(),
+                    "handles".to_string(),
+                    "device_bindings".to_string(),
+                )
+                .await
+                .unwrap(),
+            ),
+            signing_key: Arc::new(p256::ecdsa::SigningKey::from(&secret)),
+            encoding_key: Arc::new(encoding_key),
+            decoding_key: Arc::new(jsonwebtoken::DecodingKey::from_secret(&[])),
+        };
+
+        let mut oidc = (*test_oidc_config()).clone();
+        oidc.clients.insert(
+            "test-client".to_string(),
+            OidcClient {
+                client_id: "test-client".to_string(),
+                client_secret: Some("test-secret".to_string()),
+                redirect_uris: vec![],
+            },
+        );
+        let oidc = Arc::new(oidc);
+
+        let refresh_store = RefreshTokenStore::new(test_redis());
+        let token = "my-refresh-token-123";
+        let record = RefreshTokenRecord {
+            subject: "apple:123".into(),
+            client_id: "test-client".into(),
+            scopes: "openid offline_access".into(),
+            expires_at: Utc::now().timestamp() + 3600,
+            created_at: Utc::now().timestamp(),
+        };
+        refresh_store.insert(token, record).await.unwrap();
+
+        let form = TokenForm {
+            grant_type: "refresh_token".to_string(),
+            code: None,
+            redirect_uri: None,
+            client_id: Some("test-client".to_string()),
+            client_secret: Some("test-secret".to_string()),
+            code_verifier: None,
+            refresh_token: Some(token.to_string()),
+            scope: None,
+        };
+
+        let headers = HeaderMap::new();
+        let resp =
+            handle_refresh_token_grant(app_state, oidc, refresh_store.clone(), headers, form).await;
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        let body_bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let body: serde_json::Value = serde_json::from_slice(&body_bytes).unwrap();
+        assert!(!body["access_token"].as_str().unwrap().is_empty());
+        assert!(!body["id_token"].as_str().unwrap().is_empty());
+        assert!(!body["refresh_token"].as_str().unwrap().is_empty());
+
+        // Verification of rotation: original token must be gone
+        assert!(refresh_store.take(token).await.unwrap().is_none());
     }
 }

--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -1,0 +1,1153 @@
+//! OpenID Connect (OIDC) Provider endpoints
+//!
+//! Implements the OIDC endpoints required to act as an Identity Provider for
+//! OpenTDF and other OIDC relying parties:
+//!
+//! - `GET /.well-known/openid-configuration` - OIDC discovery document
+//! - `GET /.well-known/jwks.json`            - JWKS (public signing keys)
+//! - `GET /oauth/authorize`                  - Authorization endpoint (code flow)
+//! - `POST /oauth/token`                     - Token endpoint
+//! - `GET /oauth/userinfo`                   - UserInfo endpoint
+//!
+//! Token claims include OpenTDF-compatible attributes:
+//! `iss`, `sub`, `aud`, `email`, `email_verified`, `idp`,
+//! `arkavo_account_id`, `arkavo_roles`, `arkavo_entitlements`.
+//!
+//! Authentication during the authorize step is delegated to an upstream
+//! identity source (WebAuthn-issued Arkavo JWT, Apple Sign In, etc.).
+//! Operators MUST configure allowed clients/redirect URIs via environment
+//! variables (see [`OidcConfig`]).
+
+use crate::AppState;
+use crate::apple_signin;
+use crate::constants::{
+    ACCESS_TOKEN_LIFETIME_SECONDS, AUTHORIZATION_CODE_LIFETIME_SECONDS, DEFAULT_OIDC_ISSUER,
+    ID_TOKEN_LIFETIME_SECONDS,
+};
+use axum::Json;
+use axum::extract::{Extension, Form, Query};
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Redirect, Response};
+use base64::Engine;
+use chrono::Utc;
+use jsonwebtoken::{Algorithm, DecodingKey, Header, Validation, decode, encode};
+use log::{debug, error, info, warn};
+use p256::PublicKey;
+use p256::elliptic_curve::sec1::ToEncodedPoint;
+use p256::pkcs8::DecodePublicKey;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::collections::HashMap;
+use std::env;
+use std::sync::{Arc, Mutex};
+use std::time::{SystemTime, UNIX_EPOCH};
+use thiserror::Error;
+use uuid::Uuid;
+
+/// OIDC provider runtime configuration.
+///
+/// Loaded once at startup from environment variables.
+#[derive(Debug, Clone)]
+pub struct OidcConfig {
+    pub issuer: String,
+    pub clients: HashMap<String, OidcClient>,
+    /// `kid` to advertise in JWKS and embed in JWT headers.
+    pub signing_kid: String,
+    /// JWK representation of the public signing key.
+    pub jwk: Jwk,
+}
+
+#[derive(Debug, Clone)]
+pub struct OidcClient {
+    pub client_id: String,
+    /// Optional client secret. If `None`, the client is public and must use PKCE.
+    pub client_secret: Option<String>,
+    pub redirect_uris: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Jwk {
+    pub kty: String,
+    pub crv: String,
+    pub x: String,
+    pub y: String,
+    #[serde(rename = "use")]
+    pub use_: String,
+    pub alg: String,
+    pub kid: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct Jwks {
+    pub keys: Vec<Jwk>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct DiscoveryDocument {
+    pub issuer: String,
+    pub authorization_endpoint: String,
+    pub token_endpoint: String,
+    pub userinfo_endpoint: String,
+    pub jwks_uri: String,
+    pub response_types_supported: Vec<&'static str>,
+    pub subject_types_supported: Vec<&'static str>,
+    pub id_token_signing_alg_values_supported: Vec<&'static str>,
+    pub scopes_supported: Vec<&'static str>,
+    pub token_endpoint_auth_methods_supported: Vec<&'static str>,
+    pub claims_supported: Vec<&'static str>,
+    pub grant_types_supported: Vec<&'static str>,
+    pub code_challenge_methods_supported: Vec<&'static str>,
+}
+
+/// OIDC claims issued in ID/access tokens.
+///
+/// Fields are serialized into JWT payloads. The `arkavo_*` claims are
+/// OpenTDF-compatible attributes that are mapped from internal Arkavo state.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OidcClaims {
+    pub iss: String,
+    pub sub: String,
+    pub aud: String,
+    pub exp: i64,
+    pub iat: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nonce: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub email: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub email_verified: Option<bool>,
+    pub idp: String,
+    pub arkavo_account_id: String,
+    pub arkavo_roles: Vec<String>,
+    pub arkavo_entitlements: Vec<String>,
+}
+
+/// Information about an authenticated user used to mint OIDC tokens.
+#[derive(Debug, Clone)]
+pub struct AuthenticatedUser {
+    /// Stable subject identifier used in the `sub` claim.
+    /// Format: `apple:<apple_sub>` or `arkavo:<uuid>` so it's clear which IdP issued.
+    pub subject: String,
+    /// Internal Arkavo account id (UUID), mapped into `arkavo_account_id`.
+    pub arkavo_account_id: String,
+    pub email: Option<String>,
+    pub email_verified: Option<bool>,
+    /// Upstream identity provider (`apple`, `webauthn`, ...).
+    pub idp: String,
+    pub roles: Vec<String>,
+    pub entitlements: Vec<String>,
+}
+
+/// Stored authorization code metadata, keyed by the random code value.
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+struct AuthorizationCodeRecord {
+    client_id: String,
+    redirect_uri: String,
+    scope: String,
+    nonce: Option<String>,
+    code_challenge: Option<String>,
+    // Only S256 is supported (validated at the authorize endpoint), so the method
+    // is stored for diagnostics/audit but not read during verification.
+    code_challenge_method: Option<String>,
+    user: AuthenticatedUser,
+    expires_at: i64,
+}
+
+/// In-memory authorization code store.
+///
+/// Authorization codes are short-lived (10 minutes) and single-use.
+/// For multi-instance deployments this should be replaced with a shared store.
+#[derive(Clone, Default)]
+pub struct AuthorizationCodeStore {
+    inner: Arc<Mutex<HashMap<String, AuthorizationCodeRecord>>>,
+}
+
+impl AuthorizationCodeStore {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn insert(&self, code: String, record: AuthorizationCodeRecord) {
+        let mut map = self.inner.lock().unwrap();
+        // Best-effort cleanup of expired codes on each insert.
+        let now = Utc::now().timestamp();
+        map.retain(|_, v| v.expires_at > now);
+        map.insert(code, record);
+    }
+
+    fn take(&self, code: &str) -> Option<AuthorizationCodeRecord> {
+        let mut map = self.inner.lock().unwrap();
+        let record = map.remove(code)?;
+        if record.expires_at < Utc::now().timestamp() {
+            return None;
+        }
+        Some(record)
+    }
+}
+
+impl OidcConfig {
+    pub fn from_env(decoding_key_path: &str) -> Result<Self, String> {
+        let issuer = env::var("OIDC_ISSUER").unwrap_or_else(|_| DEFAULT_OIDC_ISSUER.to_string());
+
+        // Build the JWK from the configured public decoding key.
+        let pem = std::fs::read_to_string(decoding_key_path)
+            .map_err(|e| format!("Failed to read decoding key for JWKS: {}", e))?;
+        let pub_key = PublicKey::from_public_key_pem(&pem)
+            .map_err(|e| format!("Failed to parse decoding key for JWKS: {}", e))?;
+        let jwk = ec_public_key_to_jwk(&pub_key)?;
+        let signing_kid = jwk.kid.clone();
+
+        let clients = load_clients_from_env()?;
+
+        Ok(Self {
+            issuer,
+            clients,
+            signing_kid,
+            jwk,
+        })
+    }
+}
+
+fn load_clients_from_env() -> Result<HashMap<String, OidcClient>, String> {
+    let mut clients = HashMap::new();
+
+    // Primary client (typically OpenTDF). Format:
+    //   OIDC_CLIENT_ID=opentdf
+    //   OIDC_CLIENT_SECRET=...                 (optional; public client without)
+    //   OIDC_REDIRECT_URIS=https://a,https://b (comma-separated)
+    if let Ok(client_id) = env::var("OIDC_CLIENT_ID") {
+        let client_secret = env::var("OIDC_CLIENT_SECRET").ok();
+        let redirect_uris = env::var("OIDC_REDIRECT_URIS")
+            .map_err(|_| "OIDC_CLIENT_ID is set but OIDC_REDIRECT_URIS is missing".to_string())?
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+
+        clients.insert(
+            client_id.clone(),
+            OidcClient {
+                client_id,
+                client_secret,
+                redirect_uris,
+            },
+        );
+    } else {
+        warn!(
+            "OIDC_CLIENT_ID not set; /oauth/authorize and /oauth/token will reject all clients. \
+             Configure OIDC_CLIENT_ID, optional OIDC_CLIENT_SECRET, and OIDC_REDIRECT_URIS."
+        );
+    }
+
+    Ok(clients)
+}
+
+/// Convert a P-256 public key to a JWK (kty=EC, crv=P-256, alg=ES256).
+///
+/// The `kid` is the SHA-256 thumbprint per RFC 7638, base64url-encoded.
+pub fn ec_public_key_to_jwk(pub_key: &PublicKey) -> Result<Jwk, String> {
+    let encoded = pub_key.to_encoded_point(false);
+    let x_bytes = encoded
+        .x()
+        .ok_or_else(|| "EC public key missing x coordinate".to_string())?;
+    let y_bytes = encoded
+        .y()
+        .ok_or_else(|| "EC public key missing y coordinate".to_string())?;
+
+    let b64 = base64::engine::general_purpose::URL_SAFE_NO_PAD;
+    let x = b64.encode(x_bytes);
+    let y = b64.encode(y_bytes);
+
+    // RFC 7638 thumbprint: SHA-256 over canonical JSON of required JWK members.
+    let thumb_input = format!(
+        "{{\"crv\":\"P-256\",\"kty\":\"EC\",\"x\":\"{}\",\"y\":\"{}\"}}",
+        x, y
+    );
+    let mut hasher = Sha256::new();
+    hasher.update(thumb_input.as_bytes());
+    let kid = b64.encode(hasher.finalize());
+
+    Ok(Jwk {
+        kty: "EC".to_string(),
+        crv: "P-256".to_string(),
+        x,
+        y,
+        use_: "sig".to_string(),
+        alg: "ES256".to_string(),
+        kid,
+    })
+}
+
+// --------- Endpoint handlers ---------
+
+pub async fn discovery(Extension(oidc): Extension<Arc<OidcConfig>>) -> impl IntoResponse {
+    let issuer = oidc.issuer.trim_end_matches('/').to_string();
+    let doc = DiscoveryDocument {
+        authorization_endpoint: format!("{}/oauth/authorize", issuer),
+        token_endpoint: format!("{}/oauth/token", issuer),
+        userinfo_endpoint: format!("{}/oauth/userinfo", issuer),
+        jwks_uri: format!("{}/.well-known/jwks.json", issuer),
+        issuer,
+        response_types_supported: vec!["code"],
+        subject_types_supported: vec!["public"],
+        id_token_signing_alg_values_supported: vec!["ES256"],
+        scopes_supported: vec!["openid", "email", "profile", "offline_access"],
+        token_endpoint_auth_methods_supported: vec![
+            "client_secret_post",
+            "client_secret_basic",
+            "none",
+        ],
+        claims_supported: vec![
+            "iss",
+            "sub",
+            "aud",
+            "exp",
+            "iat",
+            "nonce",
+            "email",
+            "email_verified",
+            "idp",
+            "arkavo_account_id",
+            "arkavo_roles",
+            "arkavo_entitlements",
+        ],
+        grant_types_supported: vec!["authorization_code"],
+        code_challenge_methods_supported: vec!["S256"],
+    };
+    Json(doc)
+}
+
+pub async fn jwks(Extension(oidc): Extension<Arc<OidcConfig>>) -> impl IntoResponse {
+    Json(Jwks {
+        keys: vec![oidc.jwk.clone()],
+    })
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AuthorizeQuery {
+    pub response_type: String,
+    pub client_id: String,
+    pub redirect_uri: String,
+    pub scope: Option<String>,
+    pub state: Option<String>,
+    pub nonce: Option<String>,
+    pub code_challenge: Option<String>,
+    pub code_challenge_method: Option<String>,
+    /// Identity-source hint. Currently supported: `apple` (with `id_token`),
+    /// `webauthn` (Arkavo JWT in `X-Auth-Token` header).
+    pub idp: Option<String>,
+    /// Apple id_token, when `idp=apple`. Alternatively pass `X-Apple-Id-Token` header.
+    pub id_token: Option<String>,
+}
+
+/// Authorization endpoint.
+///
+/// Accepts standard OIDC authorize parameters. The end-user must already be
+/// authenticated via one of the supported upstream identity sources:
+///
+/// 1. `idp=apple` + `id_token` (or `X-Apple-Id-Token` header): validates the
+///    Apple-issued id_token, maps to an Arkavo account, and issues an
+///    authorization code.
+/// 2. `X-Auth-Token` header with a valid Arkavo JWT (from WebAuthn flow):
+///    upgrades the WebAuthn session into an OIDC authorization code.
+///
+/// If no upstream credential is presented, returns 401 with a JSON body
+/// explaining how to authenticate. (A future enhancement is a login HTML page
+/// that walks the user through these flows; for now this endpoint is intended
+/// to be driven by an SPA or native client that has already authenticated the
+/// user via one of the supported flows.)
+pub async fn authorize(
+    Extension(app_state): Extension<AppState>,
+    Extension(oidc): Extension<Arc<OidcConfig>>,
+    Extension(apple): Extension<Arc<apple_signin::AppleJwksCache>>,
+    Extension(code_store): Extension<AuthorizationCodeStore>,
+    headers: HeaderMap,
+    Query(params): Query<AuthorizeQuery>,
+) -> Response {
+    if params.response_type != "code" {
+        return oidc_error_response(
+            StatusCode::BAD_REQUEST,
+            "unsupported_response_type",
+            "Only response_type=code is supported",
+        );
+    }
+
+    let client = match oidc.clients.get(&params.client_id) {
+        Some(client) => client.clone(),
+        None => {
+            return oidc_error_response(
+                StatusCode::BAD_REQUEST,
+                "invalid_client",
+                "Unknown client_id",
+            );
+        }
+    };
+
+    if !client
+        .redirect_uris
+        .iter()
+        .any(|u| u == &params.redirect_uri)
+    {
+        return oidc_error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_redirect_uri",
+            "redirect_uri is not registered for this client",
+        );
+    }
+
+    // PKCE: if a code_challenge is supplied, the method must be S256.
+    if let Some(method) = &params.code_challenge_method
+        && method != "S256"
+    {
+        return oidc_error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_request",
+            "code_challenge_method must be S256",
+        );
+    }
+
+    let scope = params.scope.clone().unwrap_or_else(|| "openid".to_string());
+    if !scope.split_whitespace().any(|s| s == "openid") {
+        return oidc_error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_scope",
+            "scope must include openid",
+        );
+    }
+
+    // Resolve the authenticated user from one of the supported upstream sources.
+    let user = match resolve_user(&app_state, &oidc, &apple, &headers, &params).await {
+        Ok(user) => user,
+        Err(e) => return e.into_response(),
+    };
+
+    // Mint an authorization code.
+    let code = generate_authz_code();
+    let expires_at = Utc::now().timestamp() + AUTHORIZATION_CODE_LIFETIME_SECONDS;
+    code_store.insert(
+        code.clone(),
+        AuthorizationCodeRecord {
+            client_id: client.client_id.clone(),
+            redirect_uri: params.redirect_uri.clone(),
+            scope,
+            nonce: params.nonce.clone(),
+            code_challenge: params.code_challenge.clone(),
+            code_challenge_method: params.code_challenge_method.clone(),
+            user,
+            expires_at,
+        },
+    );
+
+    // Redirect back to the relying party with code + state.
+    let mut redirect = format!("{}?code={}", params.redirect_uri, code);
+    if let Some(state) = params.state.as_deref() {
+        redirect.push_str("&state=");
+        redirect
+            .push_str(&url::form_urlencoded::byte_serialize(state.as_bytes()).collect::<String>());
+    }
+    Redirect::temporary(&redirect).into_response()
+}
+
+#[derive(Debug, Deserialize)]
+pub struct TokenForm {
+    pub grant_type: String,
+    pub code: Option<String>,
+    pub redirect_uri: Option<String>,
+    pub client_id: Option<String>,
+    pub client_secret: Option<String>,
+    pub code_verifier: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct TokenResponse {
+    pub access_token: String,
+    pub token_type: String,
+    pub expires_in: i64,
+    pub id_token: String,
+    pub scope: String,
+}
+
+/// Token endpoint: exchanges an authorization code for tokens.
+pub async fn token(
+    Extension(app_state): Extension<AppState>,
+    Extension(oidc): Extension<Arc<OidcConfig>>,
+    Extension(code_store): Extension<AuthorizationCodeStore>,
+    headers: HeaderMap,
+    Form(form): Form<TokenForm>,
+) -> Response {
+    if form.grant_type != "authorization_code" {
+        return oidc_error_response(
+            StatusCode::BAD_REQUEST,
+            "unsupported_grant_type",
+            "Only authorization_code is supported",
+        );
+    }
+
+    let code = match form.code.as_deref() {
+        Some(c) if !c.is_empty() => c,
+        _ => {
+            return oidc_error_response(
+                StatusCode::BAD_REQUEST,
+                "invalid_request",
+                "code is required",
+            );
+        }
+    };
+
+    let record = match code_store.take(code) {
+        Some(r) => r,
+        None => {
+            return oidc_error_response(
+                StatusCode::BAD_REQUEST,
+                "invalid_grant",
+                "Authorization code is invalid, expired, or already redeemed",
+            );
+        }
+    };
+
+    // Authenticate the client. Support either form params or HTTP Basic.
+    let (presented_client_id, presented_client_secret) =
+        extract_client_credentials(&headers, &form);
+    let presented_client_id = match presented_client_id {
+        Some(id) => id,
+        None => {
+            return oidc_error_response(
+                StatusCode::BAD_REQUEST,
+                "invalid_request",
+                "client_id is required",
+            );
+        }
+    };
+
+    if presented_client_id != record.client_id {
+        return oidc_error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_client",
+            "client_id mismatch",
+        );
+    }
+
+    let client = match oidc.clients.get(&presented_client_id) {
+        Some(c) => c,
+        None => {
+            return oidc_error_response(
+                StatusCode::BAD_REQUEST,
+                "invalid_client",
+                "Unknown client_id",
+            );
+        }
+    };
+
+    match (&client.client_secret, &presented_client_secret) {
+        (Some(expected), Some(given)) if constant_time_eq(expected, given) => {}
+        (Some(_), _) => {
+            return oidc_error_response(
+                StatusCode::UNAUTHORIZED,
+                "invalid_client",
+                "Invalid client secret",
+            );
+        }
+        (None, _) => {
+            // Public client: require PKCE.
+            let challenge = match record.code_challenge.as_deref() {
+                Some(c) => c,
+                None => {
+                    return oidc_error_response(
+                        StatusCode::BAD_REQUEST,
+                        "invalid_request",
+                        "Public clients must use PKCE (code_challenge)",
+                    );
+                }
+            };
+            let verifier = match form.code_verifier.as_deref() {
+                Some(v) => v,
+                None => {
+                    return oidc_error_response(
+                        StatusCode::BAD_REQUEST,
+                        "invalid_request",
+                        "code_verifier is required for public clients",
+                    );
+                }
+            };
+            if !verify_pkce_s256(verifier, challenge) {
+                return oidc_error_response(
+                    StatusCode::BAD_REQUEST,
+                    "invalid_grant",
+                    "PKCE verification failed",
+                );
+            }
+        }
+    }
+
+    if let Some(redirect_uri) = form.redirect_uri.as_deref()
+        && redirect_uri != record.redirect_uri
+    {
+        return oidc_error_response(
+            StatusCode::BAD_REQUEST,
+            "invalid_grant",
+            "redirect_uri mismatch",
+        );
+    }
+
+    let now = Utc::now().timestamp();
+    let id_exp = now + ID_TOKEN_LIFETIME_SECONDS;
+    let at_exp = now + ACCESS_TOKEN_LIFETIME_SECONDS;
+
+    let id_claims = OidcClaims {
+        iss: oidc.issuer.clone(),
+        sub: record.user.subject.clone(),
+        aud: record.client_id.clone(),
+        exp: id_exp,
+        iat: now,
+        nonce: record.nonce.clone(),
+        email: record.user.email.clone(),
+        email_verified: record.user.email_verified,
+        idp: record.user.idp.clone(),
+        arkavo_account_id: record.user.arkavo_account_id.clone(),
+        arkavo_roles: record.user.roles.clone(),
+        arkavo_entitlements: record.user.entitlements.clone(),
+    };
+    let mut access_claims = id_claims.clone();
+    access_claims.exp = at_exp;
+    access_claims.nonce = None;
+
+    let mut header = Header::new(Algorithm::ES256);
+    header.kid = Some(oidc.signing_kid.clone());
+
+    let id_token = match encode(&header, &id_claims, &app_state.encoding_key) {
+        Ok(t) => t,
+        Err(e) => {
+            error!("Failed to encode id_token: {}", e);
+            return oidc_error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "server_error",
+                "Failed to issue id_token",
+            );
+        }
+    };
+    let access_token = match encode(&header, &access_claims, &app_state.encoding_key) {
+        Ok(t) => t,
+        Err(e) => {
+            error!("Failed to encode access_token: {}", e);
+            return oidc_error_response(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "server_error",
+                "Failed to issue access_token",
+            );
+        }
+    };
+
+    info!(
+        "Issued OIDC tokens for client={} sub={} idp={}",
+        record.client_id, record.user.subject, record.user.idp
+    );
+
+    let mut response = Json(TokenResponse {
+        access_token,
+        token_type: "Bearer".to_string(),
+        expires_in: ACCESS_TOKEN_LIFETIME_SECONDS,
+        id_token,
+        scope: record.scope,
+    })
+    .into_response();
+    // OAuth2 requires Cache-Control: no-store and Pragma: no-cache on token responses.
+    response.headers_mut().insert(
+        axum::http::header::CACHE_CONTROL,
+        axum::http::HeaderValue::from_static("no-store"),
+    );
+    response.headers_mut().insert(
+        axum::http::header::PRAGMA,
+        axum::http::HeaderValue::from_static("no-cache"),
+    );
+    response
+}
+
+#[derive(Debug, Serialize)]
+struct UserInfoResponse<'a> {
+    sub: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    email: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    email_verified: Option<bool>,
+    idp: &'a str,
+    arkavo_account_id: &'a str,
+    arkavo_roles: &'a [String],
+    arkavo_entitlements: &'a [String],
+}
+
+pub async fn userinfo(
+    Extension(app_state): Extension<AppState>,
+    Extension(oidc): Extension<Arc<OidcConfig>>,
+    headers: HeaderMap,
+) -> Response {
+    let token = match bearer_token(&headers) {
+        Some(t) => t,
+        None => {
+            return oidc_error_response(
+                StatusCode::UNAUTHORIZED,
+                "invalid_token",
+                "Bearer token required",
+            );
+        }
+    };
+
+    let mut validation = Validation::new(Algorithm::ES256);
+    validation.set_issuer(&[oidc.issuer.as_str()]);
+    // The aud claim is the client_id; we don't know it here, so disable that check.
+    validation.validate_aud = false;
+    let data = match decode::<OidcClaims>(&token, &app_state.decoding_key, &validation) {
+        Ok(d) => d,
+        Err(e) => {
+            debug!("UserInfo token decode failed: {}", e);
+            return oidc_error_response(
+                StatusCode::UNAUTHORIZED,
+                "invalid_token",
+                "Access token is invalid or expired",
+            );
+        }
+    };
+
+    let claims = data.claims;
+    Json(UserInfoResponse {
+        sub: &claims.sub,
+        email: claims.email.as_deref(),
+        email_verified: claims.email_verified,
+        idp: &claims.idp,
+        arkavo_account_id: &claims.arkavo_account_id,
+        arkavo_roles: &claims.arkavo_roles,
+        arkavo_entitlements: &claims.arkavo_entitlements,
+    })
+    .into_response()
+}
+
+// --------- Helpers ---------
+
+#[derive(Debug, Error)]
+pub enum AuthorizeError {
+    #[error("login_required: no upstream credential supplied")]
+    LoginRequired,
+    #[error("invalid Arkavo JWT: {0}")]
+    InvalidArkavoJwt(String),
+    #[error("invalid Apple id_token: {0}")]
+    InvalidAppleIdToken(String),
+    #[error("apple_signin error: {0}")]
+    AppleSigninError(#[from] apple_signin::AppleSigninError),
+    #[error("database error: {0}")]
+    Database(String),
+}
+
+impl IntoResponse for AuthorizeError {
+    fn into_response(self) -> Response {
+        let (status, code) = match &self {
+            AuthorizeError::LoginRequired => (StatusCode::UNAUTHORIZED, "login_required"),
+            AuthorizeError::InvalidArkavoJwt(_) | AuthorizeError::InvalidAppleIdToken(_) => {
+                (StatusCode::UNAUTHORIZED, "invalid_token")
+            }
+            AuthorizeError::AppleSigninError(_) => (StatusCode::UNAUTHORIZED, "invalid_token"),
+            AuthorizeError::Database(_) => (StatusCode::INTERNAL_SERVER_ERROR, "server_error"),
+        };
+        oidc_error_response(status, code, &self.to_string())
+    }
+}
+
+async fn resolve_user(
+    app_state: &AppState,
+    oidc: &OidcConfig,
+    apple: &apple_signin::AppleJwksCache,
+    headers: &HeaderMap,
+    params: &AuthorizeQuery,
+) -> Result<AuthenticatedUser, AuthorizeError> {
+    // Prefer explicit idp hint.
+    if params.idp.as_deref() == Some("apple")
+        || params.id_token.is_some()
+        || headers.get("X-Apple-Id-Token").is_some()
+    {
+        let token = params
+            .id_token
+            .clone()
+            .or_else(|| {
+                headers
+                    .get("X-Apple-Id-Token")
+                    .and_then(|h| h.to_str().ok().map(|s| s.to_string()))
+            })
+            .ok_or_else(|| {
+                AuthorizeError::InvalidAppleIdToken("id_token is required for idp=apple".into())
+            })?;
+
+        let apple_claims = apple_signin::verify_apple_id_token(apple, &token).await?;
+        return apple_signin::map_apple_user(app_state, &apple_claims)
+            .await
+            .map_err(|e| AuthorizeError::Database(e.to_string()));
+    }
+
+    // Otherwise expect an Arkavo JWT (from WebAuthn flow).
+    if let Some(arkavo_jwt) = headers.get("X-Auth-Token").and_then(|h| h.to_str().ok()) {
+        return resolve_from_arkavo_jwt(app_state, oidc, arkavo_jwt).await;
+    }
+
+    Err(AuthorizeError::LoginRequired)
+}
+
+async fn resolve_from_arkavo_jwt(
+    app_state: &AppState,
+    _oidc: &OidcConfig,
+    token: &str,
+) -> Result<AuthenticatedUser, AuthorizeError> {
+    // The legacy Arkavo JWTs do not yet include OIDC claims. Decode without
+    // strict exp/nbf validation to stay consistent with start_authentication
+    // (see authn.rs for the security rationale).
+    let mut validation = Validation::new(Algorithm::ES256);
+    validation.validate_nbf = false;
+    validation.validate_exp = false;
+    validation.validate_aud = false;
+    let decoding_key: &DecodingKey = &app_state.decoding_key;
+
+    #[derive(Deserialize)]
+    struct LegacyClaims {
+        sub: String,
+    }
+    let data = decode::<LegacyClaims>(token, decoding_key, &validation)
+        .map_err(|e| AuthorizeError::InvalidArkavoJwt(e.to_string()))?;
+
+    let account_id = data.claims.sub;
+    // Best-effort role/entitlement defaults. Future work: persist these on the user.
+    Ok(AuthenticatedUser {
+        subject: format!("arkavo:{}", account_id),
+        arkavo_account_id: account_id,
+        email: None,
+        email_verified: None,
+        idp: "webauthn".to_string(),
+        roles: vec!["user".to_string()],
+        entitlements: vec!["tdf:create".to_string(), "tdf:decrypt".to_string()],
+    })
+}
+
+fn extract_client_credentials(
+    headers: &HeaderMap,
+    form: &TokenForm,
+) -> (Option<String>, Option<String>) {
+    if let Some(basic) = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|h| h.to_str().ok())
+        .and_then(|s| s.strip_prefix("Basic "))
+        && let Ok(decoded) = base64::engine::general_purpose::STANDARD.decode(basic)
+        && let Ok(s) = std::str::from_utf8(&decoded)
+        && let Some((id, secret)) = s.split_once(':')
+    {
+        return (Some(id.to_string()), Some(secret.to_string()));
+    }
+    (form.client_id.clone(), form.client_secret.clone())
+}
+
+fn bearer_token(headers: &HeaderMap) -> Option<String> {
+    headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|h| h.to_str().ok())
+        .and_then(|s| s.strip_prefix("Bearer "))
+        .map(|s| s.to_string())
+}
+
+fn constant_time_eq(a: &str, b: &str) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.bytes().zip(b.bytes()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+pub fn verify_pkce_s256(verifier: &str, challenge: &str) -> bool {
+    let mut hasher = Sha256::new();
+    hasher.update(verifier.as_bytes());
+    let expected = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(hasher.finalize());
+    constant_time_eq(&expected, challenge)
+}
+
+fn generate_authz_code() -> String {
+    // 256 bits of randomness, base64url-encoded. UUID v4 supplies 122 bits;
+    // combine two for ~244 bits and append a nanosecond-based salt to make
+    // collisions practically impossible without pulling in `rand`.
+    let part1 = Uuid::new_v4();
+    let part2 = Uuid::new_v4();
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.subsec_nanos())
+        .unwrap_or(0);
+    let mut bytes = Vec::with_capacity(36);
+    bytes.extend_from_slice(part1.as_bytes());
+    bytes.extend_from_slice(part2.as_bytes());
+    bytes.extend_from_slice(&nanos.to_be_bytes());
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+}
+
+#[derive(Serialize)]
+struct OidcErrorBody {
+    error: String,
+    error_description: String,
+}
+
+fn oidc_error_response(status: StatusCode, code: &str, description: &str) -> Response {
+    (
+        status,
+        Json(OidcErrorBody {
+            error: code.to_string(),
+            error_description: description.to_string(),
+        }),
+    )
+        .into_response()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::Router;
+    use axum::body::Body;
+    use axum::http::Request;
+    use axum::routing::get;
+    use p256::SecretKey;
+    use tower::ServiceExt;
+
+    fn test_jwk() -> Jwk {
+        // Deterministic test key derived from a fixed seed.
+        let scalar = p256::elliptic_curve::ScalarPrimitive::from_slice(&[0x42u8; 32]).unwrap();
+        let secret = SecretKey::new(scalar);
+        let pub_key = secret.public_key();
+        ec_public_key_to_jwk(&pub_key).unwrap()
+    }
+
+    fn test_oidc_config() -> Arc<OidcConfig> {
+        let jwk = test_jwk();
+        let signing_kid = jwk.kid.clone();
+        Arc::new(OidcConfig {
+            issuer: "https://identity.arkavo.net".to_string(),
+            clients: HashMap::new(),
+            signing_kid,
+            jwk,
+        })
+    }
+
+    #[test]
+    fn test_jwk_serialization_shape() {
+        let jwk = test_jwk();
+        assert_eq!(jwk.kty, "EC");
+        assert_eq!(jwk.crv, "P-256");
+        assert_eq!(jwk.alg, "ES256");
+        assert_eq!(jwk.use_, "sig");
+        assert!(!jwk.x.is_empty());
+        assert!(!jwk.y.is_empty());
+        assert!(!jwk.kid.is_empty());
+
+        let json = serde_json::to_string(&jwk).unwrap();
+        assert!(json.contains("\"use\":\"sig\""));
+        assert!(json.contains("\"kty\":\"EC\""));
+        assert!(json.contains("\"crv\":\"P-256\""));
+    }
+
+    #[test]
+    fn test_jwk_thumbprint_stable() {
+        let a = test_jwk();
+        let b = test_jwk();
+        assert_eq!(a.kid, b.kid);
+    }
+
+    #[test]
+    fn test_pkce_s256_verifier_matches_challenge() {
+        let verifier = "verifier-string-with-enough-entropy-1234567890";
+        let mut hasher = Sha256::new();
+        hasher.update(verifier.as_bytes());
+        let challenge = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(hasher.finalize());
+        assert!(verify_pkce_s256(verifier, &challenge));
+        assert!(!verify_pkce_s256("wrong", &challenge));
+    }
+
+    #[test]
+    fn test_constant_time_eq() {
+        assert!(constant_time_eq("hello", "hello"));
+        assert!(!constant_time_eq("hello", "world"));
+        assert!(!constant_time_eq("hello", "hello!"));
+    }
+
+    #[test]
+    fn test_generate_authz_code_unique() {
+        let a = generate_authz_code();
+        let b = generate_authz_code();
+        assert_ne!(a, b);
+        assert!(a.len() >= 40, "authz code too short: {}", a.len());
+    }
+
+    #[test]
+    fn test_authorization_code_store_roundtrip() {
+        let store = AuthorizationCodeStore::new();
+        let code = "abc".to_string();
+        let user = AuthenticatedUser {
+            subject: "apple:123".into(),
+            arkavo_account_id: "uuid".into(),
+            email: Some("a@b".into()),
+            email_verified: Some(true),
+            idp: "apple".into(),
+            roles: vec!["user".into()],
+            entitlements: vec!["tdf:create".into()],
+        };
+        let record = AuthorizationCodeRecord {
+            client_id: "opentdf".into(),
+            redirect_uri: "https://opentdf/cb".into(),
+            scope: "openid".into(),
+            nonce: None,
+            code_challenge: None,
+            code_challenge_method: None,
+            user,
+            expires_at: Utc::now().timestamp() + 60,
+        };
+        store.insert(code.clone(), record);
+        assert!(store.take(&code).is_some());
+        // single-use: second take returns None
+        assert!(store.take(&code).is_none());
+    }
+
+    #[test]
+    fn test_authorization_code_store_expired_take_returns_none() {
+        let store = AuthorizationCodeStore::new();
+        let code = "expired".to_string();
+        let user = AuthenticatedUser {
+            subject: "apple:123".into(),
+            arkavo_account_id: "uuid".into(),
+            email: None,
+            email_verified: None,
+            idp: "apple".into(),
+            roles: vec![],
+            entitlements: vec![],
+        };
+        let record = AuthorizationCodeRecord {
+            client_id: "opentdf".into(),
+            redirect_uri: "https://opentdf/cb".into(),
+            scope: "openid".into(),
+            nonce: None,
+            code_challenge: None,
+            code_challenge_method: None,
+            user,
+            expires_at: Utc::now().timestamp() - 1,
+        };
+        store.insert(code.clone(), record);
+        assert!(store.take(&code).is_none());
+    }
+
+    #[tokio::test]
+    async fn test_discovery_endpoint_returns_expected_shape() {
+        let oidc = test_oidc_config();
+        let app = Router::new()
+            .route("/.well-known/openid-configuration", get(discovery))
+            .layer(Extension(oidc));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/.well-known/openid-configuration")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v["issuer"], "https://identity.arkavo.net");
+        assert_eq!(
+            v["authorization_endpoint"],
+            "https://identity.arkavo.net/oauth/authorize"
+        );
+        assert_eq!(
+            v["token_endpoint"],
+            "https://identity.arkavo.net/oauth/token"
+        );
+        assert_eq!(
+            v["userinfo_endpoint"],
+            "https://identity.arkavo.net/oauth/userinfo"
+        );
+        assert_eq!(
+            v["jwks_uri"],
+            "https://identity.arkavo.net/.well-known/jwks.json"
+        );
+        assert_eq!(v["id_token_signing_alg_values_supported"][0], "ES256");
+        assert!(
+            v["claims_supported"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|c| c == "arkavo_account_id")
+        );
+        assert!(
+            v["claims_supported"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|c| c == "arkavo_roles")
+        );
+        assert!(
+            v["claims_supported"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|c| c == "arkavo_entitlements")
+        );
+    }
+
+    #[tokio::test]
+    async fn test_jwks_endpoint_returns_single_key() {
+        let oidc = test_oidc_config();
+        let app = Router::new()
+            .route("/.well-known/jwks.json", get(jwks))
+            .layer(Extension(oidc.clone()));
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/.well-known/jwks.json")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(response.into_body(), 64 * 1024)
+            .await
+            .unwrap();
+        let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v["keys"].as_array().unwrap().len(), 1);
+        assert_eq!(v["keys"][0]["kty"], "EC");
+        assert_eq!(v["keys"][0]["crv"], "P-256");
+        assert_eq!(v["keys"][0]["alg"], "ES256");
+        assert_eq!(v["keys"][0]["use"], "sig");
+        assert_eq!(v["keys"][0]["kid"], oidc.jwk.kid);
+    }
+
+    #[test]
+    fn test_oidc_claims_serialization_omits_none() {
+        let claims = OidcClaims {
+            iss: "https://identity.arkavo.net".into(),
+            sub: "apple:SUB".into(),
+            aud: "opentdf".into(),
+            exp: 0,
+            iat: 0,
+            nonce: None,
+            email: None,
+            email_verified: None,
+            idp: "apple".into(),
+            arkavo_account_id: "uuid".into(),
+            arkavo_roles: vec!["user".into()],
+            arkavo_entitlements: vec!["tdf:create".into(), "tdf:decrypt".into()],
+        };
+        let json = serde_json::to_string(&claims).unwrap();
+        assert!(!json.contains("nonce"));
+        assert!(!json.contains("\"email\""));
+        assert!(json.contains("arkavo_account_id"));
+        assert!(json.contains("arkavo_roles"));
+        assert!(json.contains("arkavo_entitlements"));
+    }
+}


### PR DESCRIPTION
## Summary

Turns authnz-rs into a self-hosted Arkavo OpenID Connect identity provider so OpenTDF (and other OIDC relying parties) can trust Arkavo AuthNZ rather than trusting Apple/WebAuthn directly.

New endpoints:

| Endpoint | Purpose |
| --- | --- |
| `GET /.well-known/openid-configuration` | OIDC discovery |
| `GET /.well-known/jwks.json` | Advertises the EC P-256 signing key as a JWK (RFC 7638 thumbprint `kid`) |
| `GET /oauth/authorize` | Authorization endpoint (code flow + PKCE S256) |
| `POST /oauth/token` | ES256-signed id_token + access_token |
| `GET /oauth/userinfo` | Bearer-token-gated UserInfo |
| `POST /oauth/apple/idtoken` | Native Sign in with Apple (id_token from on-device ASAuthorization) |
| `POST /oauth/apple/callback` | Web-flow callback (form_post + id_token) |

Issued tokens carry OpenTDF-compatible claims:

```json
{
  "iss": "https://identity.arkavo.net",
  "sub": "apple:APPLE_SUB",
  "aud": "opentdf",
  "email": "user@privaterelay.appleid.com",
  "email_verified": true,
  "idp": "apple",
  "arkavo_account_id": "uuid",
  "arkavo_roles": ["user"],
  "arkavo_entitlements": ["tdf:create", "tdf:decrypt"]
}
```

Configure OpenTDF to trust:

```
issuer = https://identity.arkavo.net
jwks_uri = https://identity.arkavo.net/.well-known/jwks.json
username_claim = sub
group_claim = arkavo_roles
```

## Design

- **Apple as upstream IdP, not trust anchor**: Apple `id_token`s are validated against Apple's JWKS (cached 1h, force-refresh on `kid` miss) and mapped onto an Arkavo account (`apple-<sub>` username + synthetic `did:key:apple-<sha256(sub)>` DID). Downstream tokens are signed by *our* key, so OpenTDF only ever trusts AuthNZ.
- **Multiple upstream sources** in `/oauth/authorize`:
  - `idp=apple` + `id_token` (or `X-Apple-Id-Token` header) → Apple flow.
  - `X-Auth-Token: <Arkavo JWT>` → WebAuthn flow.
- **PKCE for public clients, client_secret for confidential clients**. Auth codes are 256+ bits, 10-min lifetime, single-use, stored in an in-memory map (swap for a shared store in multi-instance deployments).
- **`kid` is the RFC 7638 JWK thumbprint** of the public key, so it changes only when the key changes — gives operators a clean rotation story when full rotation is later added.

## Configuration

```env
export OIDC_ISSUER=https://identity.arkavo.net          # default
export OIDC_CLIENT_ID=opentdf
export OIDC_CLIENT_SECRET=...                           # omit for PKCE-only public clients
export OIDC_REDIRECT_URIS=https://opentdf.example/cb,https://opentdf.example/oauth/cb
export APPLE_CLIENT_ID=com.arkavo.app                   # only needed for Sign in with Apple
```

## Tests

`cargo test` → **47 passed** (16 new). Includes JWK serialization/thumbprint stability, PKCE S256 verifier, authorization-code-store lifecycle (single-use + expiry), end-to-end `tower::ServiceExt::oneshot` checks of discovery + JWKS shape, Apple id_token claim deserialization, and `EmailVerified` bool/string handling.

`cargo clippy` → no new warnings introduced (3 pre-existing dead-code warnings in unmodified files remain). `cargo fmt` clean.

## Known follow-ups (called out in README / module docs)

- Full key rotation in JWKS (today a single key derived from `DECODING_KEY_PATH` is exposed)
- Apple OAuth code-exchange flow (client-secret JWT signed with the operator's Apple developer key)
- Persist OIDC roles/entitlements per Arkavo account (today sensible defaults are baked into upstream auth)
- Shared `AuthorizationCodeStore` (DynamoDB/Redis) for multi-instance deployments
- Refresh tokens / `offline_access`

## Test plan

- [ ] `cargo build` and `cargo test` succeed locally
- [ ] `curl https://identity.arkavo.net/.well-known/openid-configuration` returns the expected discovery doc
- [ ] `curl https://identity.arkavo.net/.well-known/jwks.json` returns a single EC P-256 key with the operator's `kid`
- [ ] OpenTDF configured against the issuer can verify an Arkavo-issued `id_token`
- [ ] Sign in with Apple native flow: native iOS app POSTs `id_token` to `/oauth/apple/idtoken` and receives the mapped Arkavo identity record
- [ ] OIDC code flow with PKCE: public client redirected through `/oauth/authorize` (with `X-Auth-Token` from WebAuthn) → receives code → exchanges at `/oauth/token` → calls `/oauth/userinfo`


---
_Generated by [Claude Code](https://claude.ai/code/session_01RU3hyoPFqd3No8F4XXWVHn)_