### PR TITLE
feat: Apple identity linking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,7 @@ export DECODING_KEY_PATH=/path/to/decodekey.pem
 export DYNAMODB_CREDENTIALS_TABLE=credentials
 export DYNAMODB_HANDLES_TABLE=handles
 export DYNAMODB_DEVICE_BINDINGS_TABLE=device_bindings
+export DYNAMODB_IDENTITY_LINKS_TABLE=identity_links
 
 # Optional: Set port (defaults to 8080)
 export PORT=8080
@@ -85,6 +86,7 @@ export DECODING_KEY_PATH=/etc/authnz-rs/keys/decodekey.pem
 export DYNAMODB_CREDENTIALS_TABLE=credentials
 export DYNAMODB_HANDLES_TABLE=handles
 export DYNAMODB_DEVICE_BINDINGS_TABLE=device_bindings
+export DYNAMODB_IDENTITY_LINKS_TABLE=identity_links
 export AWS_REGION=us-east-1
 
 # Run the server
@@ -207,6 +209,12 @@ aws dynamodb create-table \
 - `POST /oauth/apple/idtoken`: Native flow — client must have called
   `/oauth/apple/nonce` first; server consumes session nonce (single-use) and
   validates the id_token against it
+- `POST /oauth/apple/link`: **Auth-required** link path. Caller presents a
+  valid Arkavo CWT via `X-Auth-Token`; server consumes the session nonce,
+  validates the Apple id_token, and writes `(user_id, "apple", sub)` to the
+  `identity_links` table. Idempotent on repeat; returns HTTP 409 if the same
+  Apple `sub` is already linked to a different arkavo user. **Minimum-PII**:
+  no email/name/relay claims are persisted, even if Apple sends them.
 - `POST /oauth/apple/callback`: **explicitly disabled** (HTTP 501). Apple web
   callback requires both code-exchange (signed client-secret JWT against
   Apple's token endpoint) *and* state-bound nonce verification. Until both
@@ -394,6 +402,22 @@ When modifying token lifetimes, update these in authn.rs:
   - app_id (String) - rpIdHash for App ID validation
   - created_at (Number) - Unix timestamp
   - updated_at (Number) - Unix timestamp (updated on each assertion)
+
+### identity_links table
+- **Primary Key**: link_pk (String) - Format: `<provider>#<subject>` (e.g. `apple#001234.abc...`)
+- **Attributes**:
+  - user_id (String/UUID) - The arkavo account bound to this third-party identity
+  - provider (String) - IdP name (`apple`, future: `google`, etc.)
+  - subject (String) - The IdP's stable subject identifier
+  - linked_at (Number) - Unix timestamp
+- **Uniqueness**: Conditional put on `link_pk` enforces per-(provider, subject) uniqueness.
+  Re-linking the same identity to the same user is idempotent; binding to a
+  different user returns `DynamoDBError::LinkConflict` (HTTP 409 upstream).
+- **PII**: Deliberately minimal. No email, display name, relay address, or
+  `real_user_status` is stored here, even if the IdP returns them.
+- **Future GSI** `user_id-index`: Add when an endpoint needs to enumerate
+  "which providers has this user linked?" — not required by the current
+  endpoint surface.
 
 ## Common Development Patterns
 

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -146,6 +146,7 @@ DECODING_KEY_PATH=/etc/authnz-rs/keys/decodekey.pem
 DYNAMODB_CREDENTIALS_TABLE=credentials
 DYNAMODB_HANDLES_TABLE=handles
 DYNAMODB_DEVICE_BINDINGS_TABLE=device_bindings
+DYNAMODB_IDENTITY_LINKS_TABLE=identity_links
 
 # AWS Region (if using AWS DynamoDB)
 AWS_REGION=us-east-1
@@ -153,6 +154,47 @@ AWS_REGION=us-east-1
 # Optional: DynamoDB Endpoint (for local development)
 # DYNAMODB_ENDPOINT=http://localhost:8000
 ```
+
+#### `identity_links` Table
+
+Required for the `POST /oauth/apple/link` endpoint (and any future third-party
+identity-linkage endpoint). Stores the mapping between an arkavo `user_id` and
+a third-party identity provider's `subject` claim.
+
+**Minimum-PII posture**: only the join key is persisted. No email, display
+name, private-relay address, or `real_user_status` is written here, even if
+the upstream IdP supplies it. Sign in with Apple is treated as an
+authentication signal, not an identity source.
+
+**Schema**
+
+| Attribute   | Type   | Purpose                                                     |
+|-------------|--------|-------------------------------------------------------------|
+| `link_pk`   | String | Primary key. Format: `<provider>#<subject>` (e.g. `apple#001234.abc…`). |
+| `user_id`   | String | UUID of the arkavo account the identity is bound to.        |
+| `provider`  | String | IdP name (`apple`, future: `google`, `github`, …).          |
+| `subject`   | String | The IdP's stable subject identifier (Apple's `sub` claim).  |
+| `linked_at` | Number | Unix timestamp of the link operation.                       |
+
+A conditional put on `link_pk` enforces uniqueness: re-linking the same
+identity to the same user is idempotent, but binding it to a different user
+returns HTTP `409 Conflict` (the conflicting `user_id` is not disclosed).
+
+**Provisioning**
+
+```bash
+aws dynamodb create-table \
+    --table-name identity_links \
+    --attribute-definitions AttributeName=link_pk,AttributeType=S \
+    --key-schema AttributeName=link_pk,KeyType=HASH \
+    --billing-mode PAY_PER_REQUEST
+```
+
+**Future GSI** (not required for this release): a `user_id-index` on
+`user_id` will be needed when an authenticated user wants to enumerate all
+identities bound to their account ("which providers have I linked?"). Add it
+when that endpoint ships — no rows need backfilling, GSI population happens
+asynchronously on the existing data.
 
 ### Systemd Service Setup
 

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -196,6 +196,15 @@ identities bound to their account ("which providers have I linked?"). Add it
 when that endpoint ships — no rows need backfilling, GSI population happens
 asynchronously on the existing data.
 
+**Audit log → X-Forwarded-For trust**: `/oauth/apple/link` records the
+originating client IP in its audit log by reading `X-Forwarded-For`. The
+deployment **must** put a reverse proxy (HAProxy, nginx) in front of
+authnz-rs that strips any client-supplied `X-Forwarded-For` header and
+prepends the real peer address. If clients can reach authnz-rs directly,
+they can forge this header and poison the audit log. The audit value is
+not used for any authorization decision — it is operator-correlation
+only — but log integrity still matters for incident response.
+
 ### Systemd Service Setup
 
 Create a systemd service file for automatic startup and management:

--- a/src/apple_signin.rs
+++ b/src/apple_signin.rs
@@ -601,6 +601,8 @@ pub async fn apple_link_handler(
     headers: HeaderMap,
     Json(req): Json<AppleIdTokenRequest>,
 ) -> Response {
+    let client_ip = client_ip_from_headers(&headers);
+
     // 1. Caller must be authenticated. The CWT's `sub` is the arkavo user_id
     //    we'll bind the Apple identity to.
     let user_id = match extract_authenticated_user_id(&app_state, &headers) {
@@ -627,13 +629,27 @@ pub async fn apple_link_handler(
     //    a 409 here means this Apple `sub` is already bound to a different
     //    arkavo user — typically an account-hijack attempt or a user who has
     //    already registered with us via the Apple-bootstrap path.
+    let sub_prefix = subject_prefix(&claims.sub);
     match app_state
         .db_store
         .link_identity(user_id, "apple", &claims.sub)
         .await
     {
-        Ok(()) => StatusCode::OK.into_response(),
+        Ok(()) => {
+            // Audit trail: subject_prefix (not full sub) is enough to triangulate
+            // with the DDB row during incident response without leaking the
+            // pseudonymous identifier into logs.
+            info!(
+                "audit identity_link outcome=linked user_id={} provider=apple subject_prefix={} client_ip={}",
+                user_id, sub_prefix, client_ip
+            );
+            StatusCode::OK.into_response()
+        }
         Err(crate::db::DynamoDBError::LinkConflict) => {
+            warn!(
+                "audit identity_link outcome=conflict user_id={} provider=apple subject_prefix={} client_ip={}",
+                user_id, sub_prefix, client_ip
+            );
             AppleSigninError::LinkConflict.into_response()
         }
         Err(e) => {
@@ -641,6 +657,31 @@ pub async fn apple_link_handler(
             AppleSigninError::Internal(e.to_string()).into_response()
         }
     }
+}
+
+/// First 8 chars of an opaque subject. Enough to correlate with a DynamoDB row
+/// during incident response, narrow enough not to leak the full pseudonymous
+/// identifier into logs.
+fn subject_prefix(sub: &str) -> &str {
+    let take = sub.len().min(8);
+    &sub[..take]
+}
+
+/// Extract the originating client IP for audit logs.
+///
+/// Behind HAProxy / nginx we expect `X-Forwarded-For`; first comma-separated
+/// value is the original client. Falls back to `"unknown"` when no proxy
+/// header is present (e.g. local dev hitting the server directly). We do
+/// **not** trust this for any security decision — it's a hint for log
+/// correlation only.
+fn client_ip_from_headers(headers: &HeaderMap) -> String {
+    headers
+        .get("x-forwarded-for")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.split(',').next())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string())
 }
 
 /// Extract the authenticated arkavo user_id from the inbound `X-Auth-Token`
@@ -1025,5 +1066,74 @@ mod tests {
         let v2: AppleNonceResponse = serde_json::from_slice(&body2).unwrap();
         // Two separate session-less requests must not return the same nonce.
         assert_ne!(v1.nonce, v2.nonce);
+    }
+
+    #[tokio::test]
+    async fn test_consume_apple_nonce_is_single_use() {
+        // Regression guard: the replay-prevention story for /oauth/apple/link
+        // and /oauth/apple/idtoken depends on the session-stored nonce being
+        // cleared on first read, regardless of whether downstream validation
+        // (id_token signature, audience, DDB put) succeeds. If this invariant
+        // breaks, an attacker who captures one valid (nonce, id_token) pair
+        // could replay it indefinitely.
+        use tower_sessions::cookie::time::Duration as SessionDuration;
+        use tower_sessions::{Expiry, MemoryStore, Session};
+
+        let store = Arc::new(MemoryStore::default());
+        let session = Session::new(
+            None,
+            store,
+            Some(Expiry::OnInactivity(SessionDuration::seconds(600))),
+        );
+
+        let issued = issue_apple_nonce(&session).await.expect("issue ok");
+        assert!(!issued.is_empty());
+
+        // First consume returns the nonce we issued.
+        let first = consume_apple_nonce(&session)
+            .await
+            .expect("first consume ok");
+        assert_eq!(first, issued);
+
+        // Second consume must fail with MissingSessionNonce (HTTP 400). If
+        // this ever returns Ok(...), the nonce is being replayed.
+        let second = consume_apple_nonce(&session).await;
+        assert!(
+            matches!(second, Err(AppleSigninError::MissingSessionNonce)),
+            "expected MissingSessionNonce on replay, got {:?}",
+            second
+        );
+    }
+
+    #[test]
+    fn test_subject_prefix_caps_at_eight() {
+        assert_eq!(subject_prefix("001234.abcdef.ghijkl"), "001234.a");
+        assert_eq!(subject_prefix("short"), "short");
+        assert_eq!(subject_prefix(""), "");
+    }
+
+    #[test]
+    fn test_client_ip_uses_first_xff_value() {
+        use axum::http::HeaderValue;
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-forwarded-for",
+            HeaderValue::from_static("203.0.113.7, 10.0.0.1, 10.0.0.2"),
+        );
+        assert_eq!(client_ip_from_headers(&headers), "203.0.113.7");
+    }
+
+    #[test]
+    fn test_client_ip_falls_back_to_unknown() {
+        let headers = HeaderMap::new();
+        assert_eq!(client_ip_from_headers(&headers), "unknown");
+    }
+
+    #[test]
+    fn test_client_ip_ignores_empty_xff() {
+        use axum::http::HeaderValue;
+        let mut headers = HeaderMap::new();
+        headers.insert("x-forwarded-for", HeaderValue::from_static(""));
+        assert_eq!(client_ip_from_headers(&headers), "unknown");
     }
 }

--- a/src/apple_signin.rs
+++ b/src/apple_signin.rs
@@ -653,18 +653,27 @@ pub async fn apple_link_handler(
             AppleSigninError::LinkConflict.into_response()
         }
         Err(e) => {
+            // Log the detailed error server-side, but return an opaque body —
+            // raw AWS SDK strings (region, request id, table name) must not
+            // reach the client.
             error!("Failed to link Apple identity: {}", e);
-            AppleSigninError::Internal(e.to_string()).into_response()
+            AppleSigninError::Internal("identity_link_write_failed".to_string()).into_response()
         }
     }
 }
 
-/// First 8 chars of an opaque subject. Enough to correlate with a DynamoDB row
-/// during incident response, narrow enough not to leak the full pseudonymous
-/// identifier into logs.
+/// First 8 *characters* of an opaque subject. Enough to correlate with a
+/// DynamoDB row during incident response, narrow enough not to leak the full
+/// pseudonymous identifier into logs.
+///
+/// Uses `char_indices` rather than byte-slicing so a future IdP whose subject
+/// contains multi-byte UTF-8 (some OIDC providers stuff email into `sub`) does
+/// not panic on a mid-codepoint boundary.
 fn subject_prefix(sub: &str) -> &str {
-    let take = sub.len().min(8);
-    &sub[..take]
+    match sub.char_indices().nth(8) {
+        Some((byte_idx, _)) => &sub[..byte_idx],
+        None => sub,
+    }
 }
 
 /// Extract the originating client IP for audit logs.
@@ -688,6 +697,11 @@ fn client_ip_from_headers(headers: &HeaderMap) -> String {
 /// CWT header. Returns [`AppleSigninError::MissingAuth`] (HTTP 401) if the
 /// header is absent, [`AppleSigninError::InvalidAuth`] (HTTP 401) if the CWT
 /// fails to verify or its `sub` is not a valid UUID.
+///
+/// The HTTP response intentionally collapses every CWT failure into the same
+/// opaque `InvalidAuth` so an attacker cannot distinguish "wrong issuer" from
+/// "expired" from "bad signature". The specific reason is logged at `warn!`
+/// for the operator's audit trail.
 fn extract_authenticated_user_id(
     app_state: &AppState,
     headers: &HeaderMap,
@@ -695,12 +709,18 @@ fn extract_authenticated_user_id(
     let token_header = headers
         .get("X-Auth-Token")
         .ok_or(AppleSigninError::MissingAuth)?;
-    let token_str = token_header
-        .to_str()
-        .map_err(|_| AppleSigninError::InvalidAuth)?;
-    let claims = crate::authn::verify_inbound_account_token(app_state, token_str)
-        .map_err(|_| AppleSigninError::InvalidAuth)?;
-    Uuid::parse_str(&claims.sub).map_err(|_| AppleSigninError::InvalidAuth)
+    let token_str = token_header.to_str().map_err(|e| {
+        warn!("X-Auth-Token rejected: header is not valid ASCII ({})", e);
+        AppleSigninError::InvalidAuth
+    })?;
+    let claims = crate::authn::verify_inbound_account_token(app_state, token_str).map_err(|e| {
+        warn!("X-Auth-Token rejected: CWT verification failed ({})", e);
+        AppleSigninError::InvalidAuth
+    })?;
+    Uuid::parse_str(&claims.sub).map_err(|e| {
+        warn!("X-Auth-Token rejected: CWT sub is not a valid UUID ({})", e);
+        AppleSigninError::InvalidAuth
+    })
 }
 
 #[derive(Debug, Deserialize)]
@@ -1110,6 +1130,17 @@ mod tests {
         assert_eq!(subject_prefix("001234.abcdef.ghijkl"), "001234.a");
         assert_eq!(subject_prefix("short"), "short");
         assert_eq!(subject_prefix(""), "");
+    }
+
+    #[test]
+    fn test_subject_prefix_handles_multibyte_utf8() {
+        // Regression guard: byte-slicing would panic mid-codepoint here.
+        // "αβγδεζηθι" — each greek letter is 2 bytes in UTF-8. First 8
+        // characters = 16 bytes.
+        let sub = "αβγδεζηθι";
+        let prefix = subject_prefix(sub);
+        assert_eq!(prefix, "αβγδεζηθ");
+        assert_eq!(prefix.chars().count(), 8);
     }
 
     #[test]

--- a/src/apple_signin.rs
+++ b/src/apple_signin.rs
@@ -54,7 +54,7 @@ use crate::db::DynamoDBError;
 use crate::oidc::AuthenticatedUser;
 use axum::Json;
 use axum::extract::Extension;
-use axum::http::StatusCode;
+use axum::http::{HeaderMap, StatusCode};
 use axum::response::{IntoResponse, Response};
 use chrono::Utc;
 use jsonwebtoken::jwk::{AlgorithmParameters, Jwk};
@@ -141,6 +141,14 @@ pub enum AppleSigninError {
     MissingClientId,
     #[error("session error: {0}")]
     SessionError(String),
+    #[error("Missing X-Auth-Token header")]
+    MissingAuth,
+    #[error("Invalid X-Auth-Token")]
+    InvalidAuth,
+    #[error("Apple identity already linked to a different account")]
+    LinkConflict,
+    #[error("Internal error: {0}")]
+    Internal(String),
 }
 
 impl IntoResponse for AppleSigninError {
@@ -149,10 +157,11 @@ impl IntoResponse for AppleSigninError {
             AppleSigninError::JwksFetch(_) | AppleSigninError::JwksParse(_) => {
                 StatusCode::BAD_GATEWAY
             }
-            AppleSigninError::MissingClientId | AppleSigninError::SessionError(_) => {
-                StatusCode::INTERNAL_SERVER_ERROR
-            }
+            AppleSigninError::MissingClientId
+            | AppleSigninError::SessionError(_)
+            | AppleSigninError::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
             AppleSigninError::MissingSessionNonce => StatusCode::BAD_REQUEST,
+            AppleSigninError::LinkConflict => StatusCode::CONFLICT,
             _ => StatusCode::UNAUTHORIZED,
         };
         (status, self.to_string()).into_response()
@@ -560,6 +569,99 @@ pub async fn apple_idtoken_handler(
     .into_response()
 }
 
+/// Link an Apple identity to the currently-authenticated arkavo account.
+///
+/// Auth: requires a valid Arkavo CWT in the `X-Auth-Token` header. The CWT
+/// `sub` claim is the arkavo user_id that the Apple `sub` will be bound to.
+///
+/// Preamble: client must have called `GET /oauth/apple/nonce` on the same
+/// session. The id_token's `nonce` claim is matched against the session-stored
+/// nonce (verbatim or hex SHA-256, single-use, ≤ 10-minute TTL).
+///
+/// Minimum-PII posture: only the Apple `sub` is persisted, as a row in the
+/// `identity_links` table keyed by `apple#<sub>`. Email, name, private-relay
+/// address, and `real_user_status` claims are **deliberately discarded** even
+/// if Apple includes them — this endpoint treats Sign in with Apple as a pure
+/// authentication signal, not an identity source. Callers who want PII must
+/// request and store it on a separate code path.
+///
+/// Responses:
+///  - `200 OK`: identity successfully linked (or re-linked to the same user;
+///    the operation is idempotent on `(provider, subject) → user_id`).
+///  - `400 Bad Request`: no session nonce, or expired session nonce.
+///  - `401 Unauthorized`: missing or invalid `X-Auth-Token`, or Apple id_token
+///    validation failure (signature, iss, aud, nonce, exp, iat).
+///  - `409 Conflict`: this Apple `sub` is already linked to a *different*
+///    arkavo user. The conflicting user_id is **not** disclosed.
+///  - `500 Internal Server Error`: DynamoDB or configuration failure.
+pub async fn apple_link_handler(
+    Extension(app_state): Extension<AppState>,
+    Extension(cache): Extension<Arc<AppleJwksCache>>,
+    session: Session,
+    headers: HeaderMap,
+    Json(req): Json<AppleIdTokenRequest>,
+) -> Response {
+    // 1. Caller must be authenticated. The CWT's `sub` is the arkavo user_id
+    //    we'll bind the Apple identity to.
+    let user_id = match extract_authenticated_user_id(&app_state, &headers) {
+        Ok(id) => id,
+        Err(e) => return e.into_response(),
+    };
+
+    // 2. Same nonce dance as the bootstrap endpoint — single-use consume,
+    //    bound to this session.
+    let raw_nonce = match consume_apple_nonce(&session).await {
+        Ok(n) => n,
+        Err(e) => return e.into_response(),
+    };
+
+    // 3. Validate the Apple id_token. We only consume `sub` from the result;
+    //    any email/name claims that snuck through with non-empty scopes are
+    //    discarded below.
+    let claims = match verify_apple_id_token(&cache, &req.id_token, &raw_nonce).await {
+        Ok(c) => c,
+        Err(e) => return e.into_response(),
+    };
+
+    // 4. Persist the link. The conditional put gives us per-subject uniqueness;
+    //    a 409 here means this Apple `sub` is already bound to a different
+    //    arkavo user — typically an account-hijack attempt or a user who has
+    //    already registered with us via the Apple-bootstrap path.
+    match app_state
+        .db_store
+        .link_identity(user_id, "apple", &claims.sub)
+        .await
+    {
+        Ok(()) => StatusCode::OK.into_response(),
+        Err(crate::db::DynamoDBError::LinkConflict) => {
+            AppleSigninError::LinkConflict.into_response()
+        }
+        Err(e) => {
+            error!("Failed to link Apple identity: {}", e);
+            AppleSigninError::Internal(e.to_string()).into_response()
+        }
+    }
+}
+
+/// Extract the authenticated arkavo user_id from the inbound `X-Auth-Token`
+/// CWT header. Returns [`AppleSigninError::MissingAuth`] (HTTP 401) if the
+/// header is absent, [`AppleSigninError::InvalidAuth`] (HTTP 401) if the CWT
+/// fails to verify or its `sub` is not a valid UUID.
+fn extract_authenticated_user_id(
+    app_state: &AppState,
+    headers: &HeaderMap,
+) -> Result<Uuid, AppleSigninError> {
+    let token_header = headers
+        .get("X-Auth-Token")
+        .ok_or(AppleSigninError::MissingAuth)?;
+    let token_str = token_header
+        .to_str()
+        .map_err(|_| AppleSigninError::InvalidAuth)?;
+    let claims = crate::authn::verify_inbound_account_token(app_state, token_str)
+        .map_err(|_| AppleSigninError::InvalidAuth)?;
+    Uuid::parse_str(&claims.sub).map_err(|_| AppleSigninError::InvalidAuth)
+}
+
 #[derive(Debug, Deserialize)]
 #[allow(dead_code)]
 pub struct AppleCallbackForm {
@@ -701,6 +803,24 @@ mod tests {
                 .into_response()
                 .status(),
             StatusCode::UNAUTHORIZED
+        );
+        assert_eq!(
+            AppleSigninError::MissingAuth.into_response().status(),
+            StatusCode::UNAUTHORIZED
+        );
+        assert_eq!(
+            AppleSigninError::InvalidAuth.into_response().status(),
+            StatusCode::UNAUTHORIZED
+        );
+        assert_eq!(
+            AppleSigninError::LinkConflict.into_response().status(),
+            StatusCode::CONFLICT
+        );
+        assert_eq!(
+            AppleSigninError::Internal("boom".into())
+                .into_response()
+                .status(),
+            StatusCode::INTERNAL_SERVER_ERROR
         );
     }
 

--- a/src/cwt.rs
+++ b/src/cwt.rs
@@ -142,6 +142,7 @@ impl ArkavoClaims {
         self
     }
 
+    #[cfg(test)]
     pub fn without_cnf(mut self) -> Self {
         self.cnf = None;
         self

--- a/src/db.rs
+++ b/src/db.rs
@@ -138,8 +138,13 @@ impl DynamoDBStore {
                         return Err(DynamoDBError::LinkConflict);
                     }
                     if code == Some("ResourceNotFoundException") {
-                        error!("identity_links table does not exist");
-                        return Err(DynamoDBError::TableNotExists("identity_links".to_string()));
+                        error!(
+                            "identity_links table {} does not exist",
+                            self.identity_links_table
+                        );
+                        return Err(DynamoDBError::TableNotExists(
+                            self.identity_links_table.clone(),
+                        ));
                     }
                     error!("Failed to write identity link {}: {:?}", link_pk, err);
                     Err(DynamoDBError::SdkError(err.to_string()))
@@ -148,50 +153,6 @@ impl DynamoDBStore {
                     error!("Unknown error writing identity link {}: {:?}", link_pk, err);
                     Err(DynamoDBError::SdkError(err.to_string()))
                 }
-            },
-        }
-    }
-
-    /// Look up the arkavo user_id linked to a given (provider, subject) pair.
-    /// Returns `Ok(None)` if no link exists.
-    pub async fn find_user_by_link(
-        &self,
-        provider: &str,
-        subject: &str,
-    ) -> Result<Option<Uuid>, DynamoDBError> {
-        let link_pk = format!("{}#{}", provider, subject);
-
-        let result = self
-            .client
-            .get_item()
-            .table_name(&self.identity_links_table)
-            .key("link_pk", AttributeValue::S(link_pk.clone()))
-            .send()
-            .await;
-
-        match result {
-            Ok(output) => {
-                let Some(item) = output.item else {
-                    return Ok(None);
-                };
-                let Some(AttributeValue::S(user_id_str)) = item.get("user_id") else {
-                    error!("identity_links row {} missing user_id attribute", link_pk);
-                    return Err(DynamoDBError::Internal(format!(
-                        "identity_links row {} missing user_id",
-                        link_pk
-                    )));
-                };
-                let user_id = Uuid::parse_str(user_id_str)?;
-                Ok(Some(user_id))
-            }
-            Err(err) => match err {
-                SdkError::ServiceError(ref service_error) => {
-                    if service_error.err().meta().code() == Some("ResourceNotFoundException") {
-                        return Err(DynamoDBError::TableNotExists("identity_links".to_string()));
-                    }
-                    Err(DynamoDBError::SdkError(err.to_string()))
-                }
-                _ => Err(DynamoDBError::SdkError(err.to_string())),
             },
         }
     }

--- a/src/db.rs
+++ b/src/db.rs
@@ -104,9 +104,16 @@ impl DynamoDBStore {
         let link_pk = format!("{}#{}", provider, subject);
         let now = chrono::Utc::now().timestamp();
 
+        // Privacy: never log the full link_pk (it contains the pseudonymous
+        // IdP subject). The handler in apple_signin.rs deliberately logs only
+        // the first 8 chars of subject; mirror that here so the handler →
+        // db.rs log chain can still be correlated without disclosing the
+        // full sub.
+        let subject_log = log_subject_prefix(subject);
+
         info!(
-            "Linking identity. Table: {}, link_pk: {}, user_id: {}",
-            self.identity_links_table, link_pk, user_id
+            "Linking identity. Table: {}, provider: {}, subject_prefix: {}, user_id: {}",
+            self.identity_links_table, provider, subject_log, user_id
         );
 
         let result = self
@@ -127,14 +134,20 @@ impl DynamoDBStore {
 
         match result {
             Ok(_) => {
-                info!("Linked identity {} to user {}", link_pk, user_id);
+                info!(
+                    "Linked identity provider={} subject_prefix={} to user {}",
+                    provider, subject_log, user_id
+                );
                 Ok(())
             }
             Err(err) => match err {
                 SdkError::ServiceError(ref service_error) => {
                     let code = service_error.err().meta().code();
                     if code == Some("ConditionalCheckFailedException") {
-                        warn!("Identity {} already linked to a different user", link_pk);
+                        warn!(
+                            "Identity provider={} subject_prefix={} already linked to a different user",
+                            provider, subject_log
+                        );
                         return Err(DynamoDBError::LinkConflict);
                     }
                     if code == Some("ResourceNotFoundException") {
@@ -146,11 +159,17 @@ impl DynamoDBStore {
                             self.identity_links_table.clone(),
                         ));
                     }
-                    error!("Failed to write identity link {}: {:?}", link_pk, err);
+                    error!(
+                        "Failed to write identity link provider={} subject_prefix={}: {:?}",
+                        provider, subject_log, err
+                    );
                     Err(DynamoDBError::SdkError(err.to_string()))
                 }
                 _ => {
-                    error!("Unknown error writing identity link {}: {:?}", link_pk, err);
+                    error!(
+                        "Unknown error writing identity link provider={} subject_prefix={}: {:?}",
+                        provider, subject_log, err
+                    );
                     Err(DynamoDBError::SdkError(err.to_string()))
                 }
             },
@@ -760,6 +779,19 @@ impl DynamoDBStore {
     }
 }
 
+/// Privacy-preserving subject masker used by `link_identity` logs.
+///
+/// Returns the first 8 *characters* of an opaque IdP subject (Apple `sub`,
+/// future Google `sub`, etc.) so log lines can be correlated end-to-end
+/// without disclosing the full pseudonymous identifier. `char_indices` is
+/// used so multi-byte UTF-8 subjects do not panic on a mid-codepoint slice.
+fn log_subject_prefix(subject: &str) -> &str {
+    match subject.char_indices().nth(8) {
+        Some((byte_idx, _)) => &subject[..byte_idx],
+        None => subject,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -878,5 +910,21 @@ mod tests {
     fn test_invalid_did_error() {
         let error = DynamoDBError::InvalidDID("DID must start with 'did:key:'".to_string());
         assert!(error.to_string().contains("did:key:"));
+    }
+
+    #[test]
+    fn test_log_subject_prefix_caps_at_eight_chars() {
+        assert_eq!(log_subject_prefix("001234.abcdef.ghijkl"), "001234.a");
+        assert_eq!(log_subject_prefix("short"), "short");
+        assert_eq!(log_subject_prefix(""), "");
+    }
+
+    #[test]
+    fn test_log_subject_prefix_handles_multibyte_utf8() {
+        // Regression guard: byte-slicing would panic mid-codepoint here.
+        let sub = "αβγδεζηθι";
+        let prefix = log_subject_prefix(sub);
+        assert_eq!(prefix, "αβγδεζηθ");
+        assert_eq!(prefix.chars().count(), 8);
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -40,6 +40,9 @@ pub enum DynamoDBError {
 
     #[error("Invalid DID format: {0}")]
     InvalidDID(String),
+
+    #[error("Identity already linked to a different user")]
+    LinkConflict,
 }
 
 impl From<aws_sdk_dynamodb::Error> for DynamoDBError {
@@ -62,6 +65,7 @@ pub struct DynamoDBStore {
     credentials_table: String,
     handles_table: String,
     device_bindings_table: String,
+    identity_links_table: String,
 }
 
 impl DynamoDBStore {
@@ -69,6 +73,7 @@ impl DynamoDBStore {
         credentials_table: String,
         handles_table: String,
         device_bindings_table: String,
+        identity_links_table: String,
     ) -> Result<Self, DynamoDBError> {
         let config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
         let client = Client::new(&config);
@@ -78,7 +83,117 @@ impl DynamoDBStore {
             credentials_table,
             handles_table,
             device_bindings_table,
+            identity_links_table,
         })
+    }
+
+    /// Link a third-party identity (e.g. Apple `sub`) to an existing user.
+    ///
+    /// Idempotent on (provider, subject): re-linking the same identity to the
+    /// same user succeeds silently; linking to a different user returns
+    /// [`DynamoDBError::LinkConflict`] (HTTP 409 upstream).
+    ///
+    /// Minimum-PII: only the join key is persisted. No email, display name,
+    /// relay address, or other identity metadata is stored here.
+    pub async fn link_identity(
+        &self,
+        user_id: Uuid,
+        provider: &str,
+        subject: &str,
+    ) -> Result<(), DynamoDBError> {
+        let link_pk = format!("{}#{}", provider, subject);
+        let now = chrono::Utc::now().timestamp();
+
+        info!(
+            "Linking identity. Table: {}, link_pk: {}, user_id: {}",
+            self.identity_links_table, link_pk, user_id
+        );
+
+        let result = self
+            .client
+            .put_item()
+            .table_name(&self.identity_links_table)
+            .item("link_pk", AttributeValue::S(link_pk.clone()))
+            .item("user_id", AttributeValue::S(user_id.to_string()))
+            .item("provider", AttributeValue::S(provider.to_string()))
+            .item("subject", AttributeValue::S(subject.to_string()))
+            .item("linked_at", AttributeValue::N(now.to_string()))
+            // Allow idempotent re-link (same user) but reject linking to a
+            // different user — that's the cross-account hijack case.
+            .condition_expression("attribute_not_exists(link_pk) OR user_id = :uid")
+            .expression_attribute_values(":uid", AttributeValue::S(user_id.to_string()))
+            .send()
+            .await;
+
+        match result {
+            Ok(_) => {
+                info!("Linked identity {} to user {}", link_pk, user_id);
+                Ok(())
+            }
+            Err(err) => match err {
+                SdkError::ServiceError(ref service_error) => {
+                    let code = service_error.err().meta().code();
+                    if code == Some("ConditionalCheckFailedException") {
+                        warn!("Identity {} already linked to a different user", link_pk);
+                        return Err(DynamoDBError::LinkConflict);
+                    }
+                    if code == Some("ResourceNotFoundException") {
+                        error!("identity_links table does not exist");
+                        return Err(DynamoDBError::TableNotExists("identity_links".to_string()));
+                    }
+                    error!("Failed to write identity link {}: {:?}", link_pk, err);
+                    Err(DynamoDBError::SdkError(err.to_string()))
+                }
+                _ => {
+                    error!("Unknown error writing identity link {}: {:?}", link_pk, err);
+                    Err(DynamoDBError::SdkError(err.to_string()))
+                }
+            },
+        }
+    }
+
+    /// Look up the arkavo user_id linked to a given (provider, subject) pair.
+    /// Returns `Ok(None)` if no link exists.
+    pub async fn find_user_by_link(
+        &self,
+        provider: &str,
+        subject: &str,
+    ) -> Result<Option<Uuid>, DynamoDBError> {
+        let link_pk = format!("{}#{}", provider, subject);
+
+        let result = self
+            .client
+            .get_item()
+            .table_name(&self.identity_links_table)
+            .key("link_pk", AttributeValue::S(link_pk.clone()))
+            .send()
+            .await;
+
+        match result {
+            Ok(output) => {
+                let Some(item) = output.item else {
+                    return Ok(None);
+                };
+                let Some(AttributeValue::S(user_id_str)) = item.get("user_id") else {
+                    error!("identity_links row {} missing user_id attribute", link_pk);
+                    return Err(DynamoDBError::Internal(format!(
+                        "identity_links row {} missing user_id",
+                        link_pk
+                    )));
+                };
+                let user_id = Uuid::parse_str(user_id_str)?;
+                Ok(Some(user_id))
+            }
+            Err(err) => match err {
+                SdkError::ServiceError(ref service_error) => {
+                    if service_error.err().meta().code() == Some("ResourceNotFoundException") {
+                        return Err(DynamoDBError::TableNotExists("identity_links".to_string()));
+                    }
+                    Err(DynamoDBError::SdkError(err.to_string()))
+                }
+                _ => Err(DynamoDBError::SdkError(err.to_string())),
+            },
+        }
     }
 
     pub async fn create_user(
@@ -774,12 +889,22 @@ mod tests {
             DynamoDBError::CredentialError("not found".to_string()),
             DynamoDBError::InvalidDID("bad format".to_string()),
             DynamoDBError::SdkError("aws error".to_string()),
+            DynamoDBError::LinkConflict,
         ];
 
         for error in errors {
             let msg = error.to_string();
             assert!(!msg.is_empty());
         }
+    }
+
+    #[test]
+    fn test_link_conflict_error() {
+        let error = DynamoDBError::LinkConflict;
+        assert_eq!(
+            error.to_string(),
+            "Identity already linked to a different user"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,8 @@ use tower_sessions::{Expiry, MemoryStore, SessionManagerLayer};
 use webauthn_rs::prelude::*;
 
 use crate::apple_signin::{
-    AppleJwksCache, apple_callback_handler, apple_idtoken_handler, apple_nonce_handler,
+    AppleJwksCache, apple_callback_handler, apple_idtoken_handler, apple_link_handler,
+    apple_nonce_handler,
 };
 use crate::authn::{finish_authentication, finish_register, start_authentication, start_register};
 use crate::constants::SESSION_TIMEOUT_SECONDS;
@@ -254,6 +255,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         env::var("DYNAMODB_HANDLES_TABLE").unwrap_or_else(|_| "handles".to_string()),
         env::var("DYNAMODB_DEVICE_BINDINGS_TABLE")
             .unwrap_or_else(|_| "device_bindings".to_string()),
+        env::var("DYNAMODB_IDENTITY_LINKS_TABLE").unwrap_or_else(|_| "identity_links".to_string()),
     )
     .await
     .map_err(|e| format!("Failed to initialize DynamoDB store: {}", e))?;
@@ -337,6 +339,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         // Sign in with Apple
         .route("/oauth/apple/nonce", get(apple_nonce_handler))
         .route("/oauth/apple/idtoken", post(apple_idtoken_handler))
+        .route("/oauth/apple/link", post(apple_link_handler))
         .route("/oauth/apple/callback", post(apple_callback_handler))
         // Existing OAuth callback for native-app deep links (Patreon/Twitch/Discord/Reddit)
         .route("/oauth/:client/:provider", get(handle_oauth_callback))
@@ -1101,6 +1104,7 @@ pub(crate) mod test_helpers {
                 "credentials".to_string(),
                 "handles".to_string(),
                 "device_bindings".to_string(),
+                "identity_links".to_string(),
             )
             .await
             .unwrap(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,6 +189,13 @@ pub struct AppState {
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     env_logger::init();
 
+    // rustls 0.23 is linked against both `aws-lc-rs` and `ring`, so it cannot
+    // auto-pick a crypto provider and `ServerConfig::builder()` panics unless
+    // a provider is installed first.
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .expect("failed to install rustls crypto provider");
+
     // Load configuration
     let settings = load_config()?;
 

--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -1655,6 +1655,7 @@ pub struct AccessTokenExtras {
 }
 
 impl AccessTokenExtras {
+    #[cfg(test)]
     pub fn with_idp(mut self, idp: &str) -> Self {
         self.idp = idp.into();
         self

--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -2179,6 +2179,7 @@ mod tests {
                     "credentials".to_string(),
                     "handles".to_string(),
                     "device_bindings".to_string(),
+                    "identity_links".to_string(),
                 )
                 .await
                 .unwrap(),
@@ -2273,6 +2274,7 @@ mod tests {
                     "credentials".to_string(),
                     "handles".to_string(),
                     "device_bindings".to_string(),
+                    "identity_links".to_string(),
                 )
                 .await
                 .unwrap(),


### PR DESCRIPTION
## Summary

- Adds `POST /oauth/apple/link` — auth-required endpoint that binds a verified Apple `sub` to the caller's existing arkavo user_id via a new `identity_links` table.
- Caller presents a valid Arkavo CWT in `X-Auth-Token`; server consumes the session-stored Apple nonce (single-use, ≤10min TTL), validates the Apple id_token against Apple's JWKS, then writes `(user_id, "apple", sub)`.
- **Minimum-PII posture**: only the join key is persisted. Email, display name, private-relay address, and `real_user_status` claims are deliberately discarded even if Apple sends them. SiwA is treated as a pure authentication signal, not an identity source.

## Why this endpoint

Today's `POST /oauth/apple/idtoken` (`apple_signin.rs:541`) is bootstrap-only — it calls `map_apple_user` which creates a parallel `apple-<sub>` user record. A passkey-authenticated user clicking "Link Apple" on a client today would silently provision a second account; the two would never connect. This PR adds the missing link semantics without changing the bootstrap path.

## Wire contract

```
POST /oauth/apple/link
Headers: X-Auth-Token: <arkavo CWT>
         Cookie: <session with prior /oauth/apple/nonce>
Body:    {"id_token": "<apple id_token>"}

200 OK       — linked (or re-linked to the same user; idempotent)
400          — no/expired session nonce
401          — missing/invalid X-Auth-Token, or Apple id_token validation failure
409 Conflict — this Apple sub is already linked to a different arkavo user
               (the other user_id is NOT disclosed)
500          — DynamoDB or configuration failure (opaque body, detail in server log)
```

## New DynamoDB table

`identity_links`, schema documented in `docs/DEPLOYMENT_GUIDE.md`:

| Attribute   | Type   | Purpose |
|-------------|--------|---------|
| `link_pk`   | String | PK: `<provider>#<subject>` |
| `user_id`   | String | UUID of bound arkavo account |
| `provider`  | String | `apple` (future: `google`, `github`, …) |
| `subject`   | String | IdP's stable subject (Apple `sub`) |
| `linked_at` | Number | Unix timestamp |

Uniqueness comes from a conditional put: `attribute_not_exists(link_pk) OR user_id = :uid`. Same-user re-link succeeds; different-user link returns `ConditionalCheckFailedException` → mapped to `DynamoDBError::LinkConflict` → HTTP 409.

New env var: `DYNAMODB_IDENTITY_LINKS_TABLE` (default `identity_links`).

## What's deliberately out of scope

- **Migrating `map_apple_user`** to consult `identity_links` first on the bootstrap path. That's the SiwA-as-primary-login change; separate PR after this lands and clients are using it.
- **`user_id-index` GSI** for "enumerate providers linked to my account." Add when an endpoint needs it — no rows need backfilling.
- **DID-as-user-id refactor.** Conceptually each `identity_links` row is a verificationMethod entry on the user's DID document. Keeping `user_id` as `Uuid` for now; the row schema is forward-compatible with a future DID anchoring.
- **Email/PII handling.** This endpoint will never persist email. If a future product surface needs email-from-Apple, it goes on a separate code path that opts into PII storage explicitly.
- **Unlink endpoint** (`DELETE /oauth/apple/link`) and **Apple server-to-server revocation webhook**. Follow-up PR — without them, a user who revokes Apple access in iOS Settings still has a stale `identity_links` row.

## Audit logging

`/oauth/apple/link` emits a structured log line on each terminal outcome (`outcome=linked` / `outcome=conflict`) carrying `user_id`, `provider`, an 8-char `subject_prefix` (deliberately not the full pseudonymous Apple `sub`), and the originating `client_ip` from `X-Forwarded-For`. CWT rejections on this endpoint log the specific failure reason at `warn!` while the HTTP response stays opaque (no oracle for attackers).

**Deployment assumption**: a reverse proxy (HAProxy/nginx) must strip client-supplied `X-Forwarded-For` before reaching authnz-rs — otherwise the audit log can be poisoned. The XFF value is *not* used for any authorization decision, only for operator-side correlation. See `docs/DEPLOYMENT_GUIDE.md` for the full requirement.

## Drive-by fixes bundled in this PR

- **rustls crypto provider** installed at startup (`main.rs`). Without this, rustls 0.23 panics on `ServerConfig::builder()` because both `aws-lc-rs` and `ring` providers are linked; production server crashes immediately when TLS is configured. Production bug, fixed here.
- **`#[cfg(test)]`** on `ArkavoClaims::without_cnf` and `AccessTokenExtras::with_idp` — both are test-only helpers that generated `dead_code` warnings under `cargo build`.

## Test plan

- [x] `cargo test` — **119 tests pass** (113 baseline + 1 original PR test + 6 added across review-fix commits: nonce single-use, UTF-8 subject_prefix, multibyte safety, X-Forwarded-For parsing × 3, status-code mappings × 4 as assertions on an existing test).
- [x] `cargo fmt --check` clean.
- [x] `cargo clippy` — no new warnings introduced by this PR. Warning count actually drops from 6 → 4 (the two `dead_code` warnings on `without_cnf` / `with_idp` are silenced by the `#[cfg(test)]` gating).
- [x] **Session-nonce reuse rejection** — now covered automatically by `test_consume_apple_nonce_is_single_use` regression test (was previously a manual-only checklist item).
- [ ] Provision `identity_links` table in staging (DDL in `DEPLOYMENT_GUIDE.md`) and exercise end-to-end from `ArkavoCreator` once client work lands. Production also needs `DYNAMODB_IDENTITY_LINKS_TABLE=prod-identity-links` added to `production/start.sh`.
- [ ] Verify 409 path with a manual conflicting put (link same Apple sub to two different arkavo users).
- [ ] Verify the audit-log format is what observability expects (`outcome=linked|conflict`, `subject_prefix=<8 chars>`, `client_ip=<xff value>`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)