### PR TITLE
feat: Patreon identity linking + membership materialization

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,7 @@ export DYNAMODB_CREDENTIALS_TABLE=credentials
 export DYNAMODB_HANDLES_TABLE=handles
 export DYNAMODB_DEVICE_BINDINGS_TABLE=device_bindings
 export DYNAMODB_IDENTITY_LINKS_TABLE=identity_links
+export DYNAMODB_PATREON_TOKENS_TABLE=patreon_tokens
 
 # Optional: Set port (defaults to 8080)
 export PORT=8080
@@ -62,6 +63,14 @@ export OIDC_CLIENT_OPENTDF_REDIRECT_URIS=https://opentdf.example/callback,https:
 # Optional: Sign in with Apple. Accepts a comma-separated list so the same
 # AuthNZ instance can serve an iOS bundle id + web Service ID.
 export APPLE_CLIENT_ID=com.arkavo.app,com.arkavo.web
+
+# Optional: Patreon linking + membership materialization. Set all four to
+# enable; leave any unset to disable the Patreon code paths silently
+# (POST /oauth/patreon/link returns HTTP 503 NotConfigured).
+export PATREON_CLIENT_ID=<patreon-oauth-client-id>
+export PATREON_CLIENT_SECRET=<patreon-oauth-client-secret>
+export PATREON_REDIRECT_URIS=https://identity.arkavo.net/oauth/patreon/cb,arkavo://oauth/patreon
+export PATREON_KMS_KEY_ID=alias/arkavo-patreon-token-key
 
 # Run the server
 cargo run
@@ -87,6 +96,7 @@ export DYNAMODB_CREDENTIALS_TABLE=credentials
 export DYNAMODB_HANDLES_TABLE=handles
 export DYNAMODB_DEVICE_BINDINGS_TABLE=device_bindings
 export DYNAMODB_IDENTITY_LINKS_TABLE=identity_links
+export DYNAMODB_PATREON_TOKENS_TABLE=patreon_tokens
 export AWS_REGION=us-east-1
 
 # Run the server
@@ -145,6 +155,14 @@ aws dynamodb create-table \
     --table-name device_bindings \
     --attribute-definitions AttributeName=device_id,AttributeType=S \
     --key-schema AttributeName=device_id,KeyType=HASH \
+    --billing-mode PAY_PER_REQUEST
+
+# Create patreon_tokens table (KMS-encrypted Patreon access/refresh tokens)
+aws dynamodb create-table \
+    --endpoint-url http://localhost:8000 \
+    --table-name patreon_tokens \
+    --attribute-definitions AttributeName=user_id,AttributeType=S \
+    --key-schema AttributeName=user_id,KeyType=HASH \
     --billing-mode PAY_PER_REQUEST
 ```
 
@@ -225,6 +243,47 @@ aws dynamodb create-table \
   is the canonical join key — email is optional metadata and never used to
   locate accounts (private-relay rotation safe).
 - Requires `APPLE_CLIENT_ID` to be set (one or more comma-separated values).
+
+**patreon.rs** - Patreon identity linking + membership materialization
+- Mirrors the Apple linking contract: minimum-PII row in `identity_links`
+  (`patreon#<patreon_user_id> → arkavo_user_id`, conditional put for
+  cross-account uniqueness) plus encrypted token bundle in
+  `patreon_tokens`.
+- `POST /oauth/patreon/link`: **Auth-required** link path (the *only* new
+  endpoint surface for Patreon — there is deliberately no `/me/patreon`,
+  `/entitlements/...`, or status endpoint). Body:
+  `{ "code": "<oauth-code>", "redirect_uri": "<one of PATREON_REDIRECT_URIS>",
+  "role": "creator"|"consumer" }`. Behaviour:
+    1. Verifies the inbound `X-Auth-Token` CWT (`sub` is the arkavo user_id).
+    2. Exchanges `code` at `https://www.patreon.com/api/oauth2/token`.
+    3. Fetches `/api/oauth2/v2/identity` to discover the Patreon `user.id`
+       (and, for creators, the owned `campaign.id`).
+    4. Conditional put on `identity_links` for per-Patreon-account
+       uniqueness — HTTP 409 if the Patreon account is already linked to a
+       *different* arkavo user; idempotent re-link to the same user.
+    5. Persists the encrypted token bundle (access + refresh) in
+       `patreon_tokens` keyed by arkavo `user_id`.
+    6. Invalidates the membership materialization cache for the user.
+- **Token sealing**: AES-256-GCM under a per-row 256-bit DEK; the DEK is
+  KMS-wrapped using `PATREON_KMS_KEY_ID`. One wrapped DEK per row, distinct
+  GCM nonces for the access vs refresh ciphertexts (never reuse key+nonce).
+- **Membership materialization**: surfaced *only* on the OIDC access_token
+  CWT as the `arkavo_patreon` claim. The OIDC token endpoint
+  (`handle_authorization_code_grant` and `handle_refresh_token_grant`) calls
+  [`materialize_for_user`] before minting; for consumers this queries
+  Patreon's `/identity?include=memberships,...` and builds an
+  `ArkavoPatreon { role, patreon_user_id, campaign_id?, memberships,
+  verified_at, cache_expires_at }` snapshot; for creators it just embeds the
+  stored `campaign_id`. Results are cached in Redis (with in-memory
+  fallback) for `PATREON_CACHE_TTL_SECONDS` (5 min).
+- **Fail-closed**: when Patreon is unreachable, the link is absent, or the
+  cached snapshot is stale, the mint path **omits** the `arkavo_patreon`
+  claim entirely — downstream KAS / policy enforcers must treat absence of
+  the claim as "no entitlement".
+- Patreon support is **optional**: if any of `PATREON_CLIENT_ID`,
+  `PATREON_CLIENT_SECRET`, `PATREON_REDIRECT_URIS`, or `PATREON_KMS_KEY_ID`
+  is unset, every Patreon code path is silently disabled and the link
+  endpoint returns HTTP 503 NotConfigured.
 
 **device_check.rs** - Apple DeviceCheck/App Attest integration
 - `generate_challenge`: Issues random challenge for attestation/assertion
@@ -404,10 +463,10 @@ When modifying token lifetimes, update these in authn.rs:
   - updated_at (Number) - Unix timestamp (updated on each assertion)
 
 ### identity_links table
-- **Primary Key**: link_pk (String) - Format: `<provider>#<subject>` (e.g. `apple#001234.abc...`)
+- **Primary Key**: link_pk (String) - Format: `<provider>#<subject>` (e.g. `apple#001234.abc...`, `patreon#12345`)
 - **Attributes**:
   - user_id (String/UUID) - The arkavo account bound to this third-party identity
-  - provider (String) - IdP name (`apple`, future: `google`, etc.)
+  - provider (String) - IdP name (`apple`, `patreon`, future: `google`, etc.)
   - subject (String) - The IdP's stable subject identifier
   - linked_at (Number) - Unix timestamp
 - **Uniqueness**: Conditional put on `link_pk` enforces per-(provider, subject) uniqueness.
@@ -418,6 +477,37 @@ When modifying token lifetimes, update these in authn.rs:
 - **Future GSI** `user_id-index`: Add when an endpoint needs to enumerate
   "which providers has this user linked?" — not required by the current
   endpoint surface.
+
+### patreon_tokens table
+- **Primary Key**: user_id (String/UUID) - One row per arkavo user; re-link
+  overwrites in place.
+- **Attributes**:
+  - role (String) - `creator` or `consumer`
+  - patreon_user_id (String) - Patreon's stable `data.id` from `/identity`;
+    duplicated here so the materialization read path doesn't need a second
+    lookup against `identity_links`
+  - campaign_id (String, optional) - Creator only; the Patreon `campaign.id`
+    discovered at link time
+  - scopes (String) - Space-separated OAuth scopes granted on the token
+  - access_token_ct (Binary) - AES-256-GCM ciphertext of the Patreon access
+    token under the row's DEK
+  - access_token_nonce (Binary) - 12-byte GCM nonce for access_token_ct
+  - refresh_token_ct (Binary) - AES-256-GCM ciphertext of the Patreon
+    refresh token under the same DEK
+  - refresh_token_nonce (Binary) - 12-byte GCM nonce for refresh_token_ct
+    (always distinct from access_token_nonce — never reuse key+nonce)
+  - wrapped_dek (Binary) - KMS-wrapped 256-bit DEK; decrypt with
+    `kms:Decrypt` on `PATREON_KMS_KEY_ID`
+  - token_expires_at (Number) - Unix timestamp the Patreon access token
+    expires at (per Patreon's `expires_in`)
+  - linked_at (Number) - Unix timestamp of original link
+- **Encryption**: Envelope. A DynamoDB-only compromise yields ciphertext
+  blobs but no plaintext tokens — recovery additionally requires
+  `kms:Decrypt` on the configured key.
+- **No GSI**: per-Patreon-account uniqueness is enforced via the
+  `identity_links` row (`patreon#<patreon_user_id>`), not via a secondary
+  index here. The forward `user_id → patreon` lookup uses the table's
+  primary key directly.
 
 ## Common Development Patterns
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ form_urlencoded = "1.2"
 http = "1.3"
 aws-config = "1.8"
 aws-sdk-dynamodb = "1.98"
+aws-sdk-kms = "1.98"
 bytes = "1.9"
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 url = "2.5"
@@ -51,6 +52,7 @@ coset = "0.3"            # COSE_Sign1 + COSE_Key primitives for CWT
 x509-parser = "=0.16.0"  # Certificate chain validation
 base64 = "=0.22.1"       # Encoding/decoding for attestation data
 hex = "=0.4.3"           # Hex encoding for hashes
+aes-gcm = "0.10"         # AES-256-GCM for sealing Patreon tokens under KMS-wrapped DEK
 
 [features]
 default = []

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -37,3 +37,31 @@ pub const APPLE_ISSUER: &str = "https://appleid.apple.com";
 
 /// OIDC refresh token lifetime in seconds (30 days)
 pub const REFRESH_TOKEN_LIFETIME_SECONDS: i64 = 2592000;
+
+/// Patreon OAuth2 authorize endpoint.
+///
+/// Surfaced in documentation only — the Arkavo client opens this URL itself
+/// during the consent step (authnz-rs only sees the resulting `code`).
+#[allow(dead_code)]
+pub const PATREON_AUTHORIZE_URL: &str = "https://www.patreon.com/oauth2/authorize";
+
+/// Patreon OAuth2 token endpoint
+pub const PATREON_TOKEN_URL: &str = "https://www.patreon.com/api/oauth2/token";
+
+/// Patreon API v2 identity endpoint (used to discover the linked Patreon user's
+/// id and — for creators — their owned campaign).
+pub const PATREON_IDENTITY_URL: &str = "https://www.patreon.com/api/oauth2/v2/identity";
+
+/// Patreon API v2 campaign members endpoint (templated with `{campaign_id}`).
+/// Used by membership materialization to read a creator's campaign roster
+/// and resolve a consumer's `patron_status`/tiers.
+pub const PATREON_CAMPAIGN_MEMBERS_URL_TEMPLATE: &str =
+    "https://www.patreon.com/api/oauth2/v2/campaigns/{campaign_id}/members";
+
+/// Patreon membership-materialization cache TTL in seconds (5 minutes).
+///
+/// Short enough that revocations propagate quickly, long enough that we don't
+/// hammer Patreon on every token mint. The plan calls for ~5 min;
+/// `verified_at`/`expires_at` are recorded in the cached materialization so a
+/// stale cache after Patreon goes down can be detected and rejected.
+pub const PATREON_CACHE_TTL_SECONDS: i64 = 300;

--- a/src/cwt.rs
+++ b/src/cwt.rs
@@ -50,6 +50,50 @@ pub struct CustomClaims {
     pub arkavo_account_id: Option<String>,
     pub arkavo_roles: Option<Vec<String>>,
     pub arkavo_entitlements: Option<Vec<String>>,
+    /// Materialized Patreon membership snapshot. Populated by the OIDC token
+    /// endpoint at mint time from the user's linked Patreon account. Verifiers
+    /// (KAS, downstream RPs) read this directly off the access_token CWT —
+    /// per the architecture statement, "Patreon proves membership, authnz-rs
+    /// materializes entitlement", and the materialization lives in the token.
+    pub arkavo_patreon: Option<ArkavoPatreon>,
+}
+
+/// Materialized Patreon membership for embedding in a CWT access token.
+///
+/// One snapshot per minted token. `verified_at` is the wall-clock second when
+/// the Patreon API was queried (or the cache was warmed); `cache_expires_at`
+/// is the latest second the cached snapshot may be reused without re-querying
+/// Patreon. Downstream consumers should treat any value where
+/// `cache_expires_at < now` as stale and re-mint.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ArkavoPatreon {
+    /// `creator` or `consumer`. Determines how the membership list is
+    /// interpreted: a creator owns `campaign_id`; a consumer is enrolled in
+    /// zero or more campaigns.
+    pub role: String,
+    /// Patreon user id (the `data.id` returned by `/api/oauth2/v2/identity`).
+    pub patreon_user_id: String,
+    /// Creator-only: the Patreon campaign id discovered at link time. None
+    /// for consumers (their memberships are listed in `memberships`).
+    pub campaign_id: Option<String>,
+    /// Consumer memberships. Empty for creators.
+    pub memberships: Vec<ArkavoPatreonMembership>,
+    /// Unix timestamp when this snapshot was materialized.
+    pub verified_at: i64,
+    /// Unix timestamp after which the snapshot is stale.
+    pub cache_expires_at: i64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ArkavoPatreonMembership {
+    pub campaign_id: String,
+    /// Patreon's `patron_status` string. `active_patron`, `declined_patron`,
+    /// `former_patron`, or absent (then `None`). Only `active_patron` should
+    /// be treated as conferring entitlement by downstream policy.
+    pub patron_status: Option<String>,
+    /// Patreon tier IDs the user is currently entitled to. Empty list means
+    /// the user is a free follower (no paid tier).
+    pub tier_ids: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -171,6 +215,11 @@ impl ArkavoClaims {
 
     pub fn with_arkavo_entitlements(mut self, ents: Vec<String>) -> Self {
         self.custom.arkavo_entitlements = Some(ents);
+        self
+    }
+
+    pub fn with_arkavo_patreon(mut self, p: ArkavoPatreon) -> Self {
+        self.custom.arkavo_patreon = Some(p);
         self
     }
 }
@@ -345,11 +394,136 @@ pub(crate) fn claims_to_cbor(c: &ArkavoClaims) -> Result<Vec<u8>, CwtError> {
             Value::Array(v.iter().map(|s| Value::Text(s.clone())).collect()),
         ));
     }
+    if let Some(p) = &c.custom.arkavo_patreon {
+        entries.push((Value::Text("arkavo_patreon".into()), patreon_to_cbor(p)));
+    }
 
     let mut bytes = Vec::new();
     ciborium::ser::into_writer(&Value::Map(entries), &mut bytes)
         .map_err(|_| CwtError::Malformed)?;
     Ok(bytes)
+}
+
+fn patreon_to_cbor(p: &ArkavoPatreon) -> Value {
+    let mut entries: Vec<(Value, Value)> = Vec::new();
+    entries.push((Value::Text("role".into()), Value::Text(p.role.clone())));
+    entries.push((
+        Value::Text("patreon_user_id".into()),
+        Value::Text(p.patreon_user_id.clone()),
+    ));
+    if let Some(cid) = &p.campaign_id {
+        entries.push((Value::Text("campaign_id".into()), Value::Text(cid.clone())));
+    }
+    if !p.memberships.is_empty() {
+        let arr: Vec<Value> = p
+            .memberships
+            .iter()
+            .map(|m| {
+                let mut m_entries: Vec<(Value, Value)> = Vec::new();
+                m_entries.push((
+                    Value::Text("campaign_id".into()),
+                    Value::Text(m.campaign_id.clone()),
+                ));
+                if let Some(status) = &m.patron_status {
+                    m_entries.push((
+                        Value::Text("patron_status".into()),
+                        Value::Text(status.clone()),
+                    ));
+                }
+                m_entries.push((
+                    Value::Text("tier_ids".into()),
+                    Value::Array(m.tier_ids.iter().map(|t| Value::Text(t.clone())).collect()),
+                ));
+                Value::Map(m_entries)
+            })
+            .collect();
+        entries.push((Value::Text("memberships".into()), Value::Array(arr)));
+    }
+    entries.push((
+        Value::Text("verified_at".into()),
+        Value::Integer(p.verified_at.into()),
+    ));
+    entries.push((
+        Value::Text("cache_expires_at".into()),
+        Value::Integer(p.cache_expires_at.into()),
+    ));
+    Value::Map(entries)
+}
+
+fn patreon_from_cbor(v: Value) -> Result<ArkavoPatreon, CwtError> {
+    let Value::Map(entries) = v else {
+        return Err(CwtError::Malformed);
+    };
+    let mut role: Option<String> = None;
+    let mut patreon_user_id: Option<String> = None;
+    let mut campaign_id: Option<String> = None;
+    let mut memberships: Vec<ArkavoPatreonMembership> = Vec::new();
+    let mut verified_at: Option<i64> = None;
+    let mut cache_expires_at: Option<i64> = None;
+
+    for (k, vv) in entries {
+        let key = match k {
+            Value::Text(s) => s,
+            _ => return Err(CwtError::Malformed),
+        };
+        match (key.as_str(), vv) {
+            ("role", Value::Text(s)) => role = Some(s),
+            ("patreon_user_id", Value::Text(s)) => patreon_user_id = Some(s),
+            ("campaign_id", Value::Text(s)) => campaign_id = Some(s),
+            ("memberships", Value::Array(arr)) => {
+                for item in arr {
+                    let Value::Map(m_entries) = item else {
+                        return Err(CwtError::Malformed);
+                    };
+                    let mut m_campaign_id: Option<String> = None;
+                    let mut m_status: Option<String> = None;
+                    let mut m_tiers: Vec<String> = Vec::new();
+                    for (mk, mv) in m_entries {
+                        let mkey = match mk {
+                            Value::Text(s) => s,
+                            _ => return Err(CwtError::Malformed),
+                        };
+                        match (mkey.as_str(), mv) {
+                            ("campaign_id", Value::Text(s)) => m_campaign_id = Some(s),
+                            ("patron_status", Value::Text(s)) => m_status = Some(s),
+                            ("tier_ids", Value::Array(a)) => {
+                                m_tiers = a
+                                    .into_iter()
+                                    .map(|t| match t {
+                                        Value::Text(s) => Ok(s),
+                                        _ => Err(CwtError::Malformed),
+                                    })
+                                    .collect::<Result<_, _>>()?;
+                            }
+                            _ => {}
+                        }
+                    }
+                    memberships.push(ArkavoPatreonMembership {
+                        campaign_id: m_campaign_id.ok_or(CwtError::Malformed)?,
+                        patron_status: m_status,
+                        tier_ids: m_tiers,
+                    });
+                }
+            }
+            ("verified_at", Value::Integer(n)) => {
+                let v: i128 = n.into();
+                verified_at = Some(i64::try_from(v).map_err(|_| CwtError::Malformed)?);
+            }
+            ("cache_expires_at", Value::Integer(n)) => {
+                let v: i128 = n.into();
+                cache_expires_at = Some(i64::try_from(v).map_err(|_| CwtError::Malformed)?);
+            }
+            _ => {}
+        }
+    }
+    Ok(ArkavoPatreon {
+        role: role.ok_or(CwtError::Malformed)?,
+        patreon_user_id: patreon_user_id.ok_or(CwtError::Malformed)?,
+        campaign_id,
+        memberships,
+        verified_at: verified_at.ok_or(CwtError::Malformed)?,
+        cache_expires_at: cache_expires_at.ok_or(CwtError::Malformed)?,
+    })
 }
 
 pub(crate) fn claims_from_cbor(bytes: &[u8]) -> Result<ArkavoClaims, CwtError> {
@@ -495,6 +669,9 @@ pub(crate) fn claims_from_cbor(bytes: &[u8]) -> Result<ArkavoClaims, CwtError> {
                     })
                     .collect();
                 custom.arkavo_entitlements = Some(parts?);
+            }
+            (Value::Text(s), v) if s == "arkavo_patreon" => {
+                custom.arkavo_patreon = Some(patreon_from_cbor(v)?);
             }
             _ => {} // Ignore unknown claims (forward-compat).
         }
@@ -701,6 +878,51 @@ mod tests {
         assert_eq!(decoded.iat, c.iat);
         assert_eq!(decoded.cti, c.cti);
         assert!(decoded.cnf.is_none());
+    }
+
+    #[test]
+    fn cbor_roundtrip_arkavo_patreon_consumer_claim() {
+        let snap = ArkavoPatreon {
+            role: "consumer".into(),
+            patreon_user_id: "patreon-user-42".into(),
+            campaign_id: None,
+            memberships: vec![
+                ArkavoPatreonMembership {
+                    campaign_id: "camp-1".into(),
+                    patron_status: Some("active_patron".into()),
+                    tier_ids: vec!["tier-gold".into(), "tier-vip".into()],
+                },
+                ArkavoPatreonMembership {
+                    campaign_id: "camp-2".into(),
+                    patron_status: Some("former_patron".into()),
+                    tier_ids: vec![],
+                },
+            ],
+            verified_at: 1_700_000_000,
+            cache_expires_at: 1_700_000_300,
+        };
+        let mut c = ArkavoClaims::oidc_access("iss-1", "arkavo:abc", "opentdf", 1);
+        c = c.with_arkavo_patreon(snap.clone());
+        let bytes = claims_to_cbor(&c).expect("encode");
+        let decoded = claims_from_cbor(&bytes).expect("decode");
+        assert_eq!(decoded.custom.arkavo_patreon, Some(snap));
+    }
+
+    #[test]
+    fn cbor_roundtrip_arkavo_patreon_creator_claim() {
+        let snap = ArkavoPatreon {
+            role: "creator".into(),
+            patreon_user_id: "patreon-user-7".into(),
+            campaign_id: Some("camp-9".into()),
+            memberships: vec![],
+            verified_at: 1_700_000_000,
+            cache_expires_at: 1_700_000_300,
+        };
+        let mut c = ArkavoClaims::oidc_access("iss-1", "arkavo:creator", "opentdf", 1);
+        c = c.with_arkavo_patreon(snap.clone());
+        let bytes = claims_to_cbor(&c).expect("encode");
+        let decoded = claims_from_cbor(&bytes).expect("decode");
+        assert_eq!(decoded.custom.arkavo_patreon, Some(snap));
     }
 
     #[test]

--- a/src/db.rs
+++ b/src/db.rs
@@ -66,6 +66,7 @@ pub struct DynamoDBStore {
     handles_table: String,
     device_bindings_table: String,
     identity_links_table: String,
+    patreon_tokens_table: String,
 }
 
 impl DynamoDBStore {
@@ -74,6 +75,7 @@ impl DynamoDBStore {
         handles_table: String,
         device_bindings_table: String,
         identity_links_table: String,
+        patreon_tokens_table: String,
     ) -> Result<Self, DynamoDBError> {
         let config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
         let client = Client::new(&config);
@@ -84,7 +86,124 @@ impl DynamoDBStore {
             handles_table,
             device_bindings_table,
             identity_links_table,
+            patreon_tokens_table,
         })
+    }
+
+    /// Persist (or replace) the Patreon token bundle for a user.
+    ///
+    /// This is keyed by the arkavo `user_id` — one Patreon link per user, per
+    /// role. Re-linking overwrites the previous row (a user can re-authorize
+    /// to refresh consent or change role from consumer to creator). The
+    /// per-(provider, patreon_user_id) uniqueness invariant is enforced
+    /// separately via [`link_identity`] on the `identity_links` table, which
+    /// mirrors the Apple linking pattern.
+    pub async fn put_patreon_link(
+        &self,
+        link: &crate::patreon::PatreonLink,
+    ) -> Result<(), DynamoDBError> {
+        info!(
+            "Persisting Patreon link. Table: {}, user_id: {}, role: {}",
+            self.patreon_tokens_table, link.user_id, link.role
+        );
+
+        let mut item_builder = self
+            .client
+            .put_item()
+            .table_name(&self.patreon_tokens_table)
+            .item("user_id", AttributeValue::S(link.user_id.to_string()))
+            .item("role", AttributeValue::S(link.role.clone()))
+            .item(
+                "patreon_user_id",
+                AttributeValue::S(link.patreon_user_id.clone()),
+            )
+            .item("scopes", AttributeValue::S(link.scopes.clone()))
+            .item(
+                "access_token_ct",
+                AttributeValue::B(aws_sdk_dynamodb::primitives::Blob::new(
+                    link.access_token_ct.clone(),
+                )),
+            )
+            .item(
+                "access_token_nonce",
+                AttributeValue::B(aws_sdk_dynamodb::primitives::Blob::new(
+                    link.access_token_nonce.clone(),
+                )),
+            )
+            .item(
+                "refresh_token_ct",
+                AttributeValue::B(aws_sdk_dynamodb::primitives::Blob::new(
+                    link.refresh_token_ct.clone(),
+                )),
+            )
+            .item(
+                "refresh_token_nonce",
+                AttributeValue::B(aws_sdk_dynamodb::primitives::Blob::new(
+                    link.refresh_token_nonce.clone(),
+                )),
+            )
+            .item(
+                "wrapped_dek",
+                AttributeValue::B(aws_sdk_dynamodb::primitives::Blob::new(
+                    link.wrapped_dek.clone(),
+                )),
+            )
+            .item(
+                "token_expires_at",
+                AttributeValue::N(link.token_expires_at.to_string()),
+            )
+            .item("linked_at", AttributeValue::N(link.linked_at.to_string()));
+        if let Some(cid) = &link.campaign_id {
+            item_builder = item_builder.item("campaign_id", AttributeValue::S(cid.clone()));
+        }
+
+        match item_builder.send().await {
+            Ok(_) => Ok(()),
+            Err(err) => match err {
+                SdkError::ServiceError(ref service_error) => {
+                    if service_error.err().meta().code() == Some("ResourceNotFoundException") {
+                        error!(
+                            "patreon_tokens table {} does not exist",
+                            self.patreon_tokens_table
+                        );
+                        return Err(DynamoDBError::TableNotExists(
+                            self.patreon_tokens_table.clone(),
+                        ));
+                    }
+                    error!("Failed to write to patreon_tokens table: {:?}", err);
+                    Err(DynamoDBError::SdkError(err.to_string()))
+                }
+                _ => {
+                    error!("Unknown error writing to patreon_tokens table: {:?}", err);
+                    Err(DynamoDBError::SdkError(err.to_string()))
+                }
+            },
+        }
+    }
+
+    /// Read the Patreon token bundle for a user, if any.
+    ///
+    /// Returns `Ok(None)` when the user has not linked Patreon.
+    pub async fn get_patreon_link(
+        &self,
+        user_id: Uuid,
+    ) -> Result<Option<crate::patreon::PatreonLink>, DynamoDBError> {
+        let result = self
+            .client
+            .get_item()
+            .table_name(&self.patreon_tokens_table)
+            .key("user_id", AttributeValue::S(user_id.to_string()))
+            .send()
+            .await
+            .map_err(|err| {
+                error!("Failed to read patreon_tokens for {}: {:?}", user_id, err);
+                DynamoDBError::SdkError(err.to_string())
+            })?;
+
+        let Some(item) = result.item else {
+            return Ok(None);
+        };
+        item_to_patreon_link(&item).map(Some)
     }
 
     /// Link a third-party identity (e.g. Apple `sub`) to an existing user.
@@ -777,6 +896,73 @@ impl DynamoDBStore {
             updated_at,
         })
     }
+}
+
+fn item_to_patreon_link(
+    item: &std::collections::HashMap<String, AttributeValue>,
+) -> Result<crate::patreon::PatreonLink, DynamoDBError> {
+    fn read_string(
+        item: &std::collections::HashMap<String, AttributeValue>,
+        key: &str,
+    ) -> Result<String, DynamoDBError> {
+        item.get(key)
+            .ok_or_else(|| DynamoDBError::Internal(format!("Missing patreon field {}", key)))?
+            .as_s()
+            .map_err(|_| DynamoDBError::Internal(format!("Invalid patreon field {}", key)))
+            .map(|s| s.to_string())
+    }
+    fn read_bytes(
+        item: &std::collections::HashMap<String, AttributeValue>,
+        key: &str,
+    ) -> Result<Vec<u8>, DynamoDBError> {
+        item.get(key)
+            .ok_or_else(|| DynamoDBError::Internal(format!("Missing patreon field {}", key)))?
+            .as_b()
+            .map_err(|_| DynamoDBError::Internal(format!("Invalid patreon field {}", key)))
+            .map(|b| b.as_ref().to_vec())
+    }
+    fn read_i64(
+        item: &std::collections::HashMap<String, AttributeValue>,
+        key: &str,
+    ) -> Result<i64, DynamoDBError> {
+        item.get(key)
+            .ok_or_else(|| DynamoDBError::Internal(format!("Missing patreon field {}", key)))?
+            .as_n()
+            .map_err(|_| DynamoDBError::Internal(format!("Invalid patreon field {}", key)))?
+            .parse::<i64>()
+            .map_err(|_| DynamoDBError::Internal(format!("Unparseable number for {}", key)))
+    }
+
+    let user_id = Uuid::parse_str(&read_string(item, "user_id")?)?;
+    let role = read_string(item, "role")?;
+    let patreon_user_id = read_string(item, "patreon_user_id")?;
+    let scopes = read_string(item, "scopes")?;
+    let access_token_ct = read_bytes(item, "access_token_ct")?;
+    let access_token_nonce = read_bytes(item, "access_token_nonce")?;
+    let refresh_token_ct = read_bytes(item, "refresh_token_ct")?;
+    let refresh_token_nonce = read_bytes(item, "refresh_token_nonce")?;
+    let wrapped_dek = read_bytes(item, "wrapped_dek")?;
+    let token_expires_at = read_i64(item, "token_expires_at")?;
+    let linked_at = read_i64(item, "linked_at")?;
+    let campaign_id = item
+        .get("campaign_id")
+        .and_then(|v| v.as_s().ok())
+        .map(|s| s.to_string());
+
+    Ok(crate::patreon::PatreonLink {
+        user_id,
+        role,
+        patreon_user_id,
+        campaign_id,
+        scopes,
+        access_token_ct,
+        access_token_nonce,
+        refresh_token_ct,
+        refresh_token_nonce,
+        wrapped_dek,
+        token_expires_at,
+        linked_at,
+    })
 }
 
 /// Privacy-preserving subject masker used by `link_identity` logs.

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,7 @@ use crate::oidc::{
     cose_keys as oidc_cose_keys, discovery as oidc_discovery, jwks as oidc_jwks,
     token as oidc_token, userinfo as oidc_userinfo,
 };
+use crate::patreon::{PatreonOAuthConfig, PatreonState, build_kms_sealer, patreon_link_handler};
 
 mod apple_signin;
 mod authn;
@@ -52,6 +53,7 @@ mod cwt;
 mod db;
 mod device_check;
 mod oidc;
+mod patreon;
 
 // HTTP/3 server function (feature-gated)
 #[cfg(feature = "http3")]
@@ -263,6 +265,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         env::var("DYNAMODB_DEVICE_BINDINGS_TABLE")
             .unwrap_or_else(|_| "device_bindings".to_string()),
         env::var("DYNAMODB_IDENTITY_LINKS_TABLE").unwrap_or_else(|_| "identity_links".to_string()),
+        env::var("DYNAMODB_PATREON_TOKENS_TABLE").unwrap_or_else(|_| "patreon_tokens".to_string()),
     )
     .await
     .map_err(|e| format!("Failed to initialize DynamoDB store: {}", e))?;
@@ -314,8 +317,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             .map_err(|e| format!("Failed to load OIDC configuration: {}", e))?,
     );
     let oidc_code_store = AuthorizationCodeStore::new(redis_client.clone());
-    let oidc_refresh_store = RefreshTokenStore::new(redis_client);
+    let oidc_refresh_store = RefreshTokenStore::new(redis_client.clone());
     let apple_jwks_cache = Arc::new(AppleJwksCache::new());
+
+    // Patreon support is optional; if PATREON_CLIENT_ID isn't set, every
+    // Patreon code path (link handler + access_token enrichment) is silently
+    // disabled. This lets non-Patreon deployments run without forced config.
+    let patreon_oauth = PatreonOAuthConfig::from_env();
+    let patreon_sealer = build_kms_sealer().await;
+    if patreon_oauth.is_some() && patreon_sealer.is_none() {
+        log::warn!(
+            "PATREON_CLIENT_ID is set but PATREON_KMS_KEY_ID is not — \
+             /oauth/patreon/link will reject with 503 (NotConfigured)"
+        );
+    }
+    let patreon_state = PatreonState::new(patreon_oauth, patreon_sealer, redis_client);
 
     let session_store = MemoryStore::default();
     let session_service = ServiceBuilder::new().layer(
@@ -348,6 +364,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .route("/oauth/apple/idtoken", post(apple_idtoken_handler))
         .route("/oauth/apple/link", post(apple_link_handler))
         .route("/oauth/apple/callback", post(apple_callback_handler))
+        // Patreon linking (mirrors /oauth/apple/link — same auth-required,
+        // identity_links-write contract). Membership + tier are surfaced
+        // only on the resulting OIDC access_token CWT; there is deliberately
+        // no /me/patreon or /entitlements endpoint surface.
+        .route("/oauth/patreon/link", post(patreon_link_handler))
         // Existing OAuth callback for native-app deep links (Patreon/Twitch/Discord/Reddit)
         .route("/oauth/:client/:provider", get(handle_oauth_callback))
         .route("/register/:username", get(start_register))
@@ -367,6 +388,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .layer(Extension(oidc_code_store))
         .layer(Extension(oidc_refresh_store))
         .layer(Extension(apple_jwks_cache))
+        .layer(Extension(patreon_state))
         .layer(session_service)
         .layer(Extension(apple_app_site_association))
         .fallback(handler_fallback);
@@ -1112,6 +1134,7 @@ pub(crate) mod test_helpers {
                 "handles".to_string(),
                 "device_bindings".to_string(),
                 "identity_links".to_string(),
+                "patreon_tokens".to_string(),
             )
             .await
             .unwrap(),

--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -747,6 +747,7 @@ pub async fn token(
     Extension(oidc): Extension<Arc<OidcConfig>>,
     Extension(code_store): Extension<AuthorizationCodeStore>,
     Extension(refresh_store): Extension<RefreshTokenStore>,
+    Extension(patreon): Extension<crate::patreon::PatreonState>,
     headers: HeaderMap,
     Form(form): Form<TokenForm>,
 ) -> Response {
@@ -757,6 +758,7 @@ pub async fn token(
                 oidc,
                 code_store,
                 refresh_store,
+                patreon,
                 headers,
                 form,
             )
@@ -766,7 +768,7 @@ pub async fn token(
             handle_client_credentials_grant(app_state, oidc, headers, form).await
         }
         "refresh_token" => {
-            handle_refresh_token_grant(app_state, oidc, refresh_store, headers, form).await
+            handle_refresh_token_grant(app_state, oidc, refresh_store, patreon, headers, form).await
         }
         _ => oidc_error_response(
             StatusCode::BAD_REQUEST,
@@ -781,6 +783,7 @@ async fn handle_authorization_code_grant(
     oidc: Arc<OidcConfig>,
     code_store: AuthorizationCodeStore,
     refresh_store: RefreshTokenStore,
+    patreon: crate::patreon::PatreonState,
     headers: HeaderMap,
     form: TokenForm,
 ) -> Response {
@@ -921,6 +924,14 @@ async fn handle_authorization_code_grant(
             );
         }
     };
+    // Materialize Patreon membership (if linked) for embedding in the
+    // access_token CWT. Per the architecture statement: "Patreon proves
+    // membership, authnz-rs materializes entitlement." Fails closed — the
+    // helper returns None on any Patreon-side error so the resulting token
+    // simply omits the `arkavo_patreon` claim and downstream policy treats
+    // that as "no entitlement".
+    let arkavo_patreon = resolve_arkavo_patreon(&app_state, &patreon, &record.user).await;
+
     let access_token = {
         let extras = AccessTokenExtras {
             idp: record.user.idp.clone(),
@@ -929,6 +940,7 @@ async fn handle_authorization_code_grant(
             arkavo_account_id: Some(record.user.arkavo_account_id.clone()),
             arkavo_roles: Some(record.user.roles.clone()),
             arkavo_entitlements: Some(record.user.entitlements.clone()),
+            arkavo_patreon,
         };
         match mint_access_token(
             &app_state,
@@ -1095,6 +1107,8 @@ async fn handle_client_credentials_grant(
             arkavo_account_id: Some(id_claims.arkavo_account_id.clone()),
             arkavo_roles: Some(id_claims.arkavo_roles.clone()),
             arkavo_entitlements: Some(id_claims.arkavo_entitlements.clone()),
+            // Service accounts (client_credentials) have no Patreon link.
+            arkavo_patreon: None,
         };
         match mint_access_token(
             &app_state,
@@ -1144,6 +1158,7 @@ async fn handle_refresh_token_grant(
     app_state: AppState,
     oidc: Arc<OidcConfig>,
     refresh_store: RefreshTokenStore,
+    patreon: crate::patreon::PatreonState,
     headers: HeaderMap,
     form: TokenForm,
 ) -> Response {
@@ -1275,6 +1290,16 @@ async fn handle_refresh_token_grant(
             );
         }
     };
+    // Re-materialize Patreon membership on refresh so a downgrade/cancel
+    // since the original code exchange propagates within the 5-min cache TTL.
+    // Only the user-flow subjects (not service-account `client:...`) carry a
+    // resolvable arkavo user_id; the parse_uuid_from_subject helper returns
+    // None for service accounts so we skip the lookup cleanly.
+    let arkavo_patreon = match parse_uuid_from_subject(&record.subject) {
+        Some(user_id) => crate::patreon::materialize_for_user(&app_state, &patreon, user_id).await,
+        None => None,
+    };
+
     let access_token = {
         let extras = AccessTokenExtras {
             idp: id_claims.idp.clone(),
@@ -1283,6 +1308,7 @@ async fn handle_refresh_token_grant(
             arkavo_account_id: Some(id_claims.arkavo_account_id.clone()),
             arkavo_roles: Some(id_claims.arkavo_roles.clone()),
             arkavo_entitlements: Some(id_claims.arkavo_entitlements.clone()),
+            arkavo_patreon,
         };
         match mint_access_token(
             &app_state,
@@ -1609,6 +1635,30 @@ pub fn verify_pkce_s256(verifier: &str, challenge: &str) -> bool {
     constant_time_eq(&expected, challenge)
 }
 
+/// Pull the arkavo `user_id` UUID off an [`AuthenticatedUser`] and run the
+/// Patreon materialization. We prefer `arkavo_account_id` (always set for
+/// user flows) but fall back to parsing the `arkavo:` subject so this stays
+/// resilient to refactors of `AuthenticatedUser`. Service-account subjects
+/// (`client:...`) don't have a Patreon link by construction — return None.
+async fn resolve_arkavo_patreon(
+    app_state: &AppState,
+    patreon: &crate::patreon::PatreonState,
+    user: &AuthenticatedUser,
+) -> Option<crate::cwt::ArkavoPatreon> {
+    let user_id = Uuid::parse_str(&user.arkavo_account_id)
+        .ok()
+        .or_else(|| parse_uuid_from_subject(&user.subject))?;
+    crate::patreon::materialize_for_user(app_state, patreon, user_id).await
+}
+
+/// Strip the `arkavo:` prefix (if present) and parse the remainder as a
+/// UUID. Returns None for service-account subjects (`client:<id>`) and any
+/// other subject format we don't recognize.
+fn parse_uuid_from_subject(subject: &str) -> Option<Uuid> {
+    let raw = subject.strip_prefix("arkavo:").unwrap_or(subject);
+    Uuid::parse_str(raw).ok()
+}
+
 fn generate_authz_code() -> String {
     // 256 bits of randomness, base64url-encoded. UUID v4 supplies 122 bits;
     // combine two for ~244 bits and append a nanosecond-based salt to make
@@ -1652,6 +1702,12 @@ pub struct AccessTokenExtras {
     pub arkavo_account_id: Option<String>,
     pub arkavo_roles: Option<Vec<String>>,
     pub arkavo_entitlements: Option<Vec<String>>,
+    /// Materialized Patreon membership snapshot. Set by the OIDC token
+    /// endpoint before calling [`mint_access_token`] when the authenticated
+    /// user has a Patreon link; embedded into the CWT `arkavo_patreon` claim.
+    /// `None` when the user is unlinked, Patreon support is disabled, or
+    /// materialization failed (fail-closed posture per the plan).
+    pub arkavo_patreon: Option<crate::cwt::ArkavoPatreon>,
 }
 
 impl AccessTokenExtras {
@@ -1690,6 +1746,9 @@ pub fn mint_access_token(
         }
         if let Some(ents) = e.arkavo_entitlements {
             claims = claims.with_arkavo_entitlements(ents);
+        }
+        if let Some(p) = e.arkavo_patreon {
+            claims = claims.with_arkavo_patreon(p);
         }
     }
     if let Some(c) = cnf {
@@ -1869,6 +1928,13 @@ mod tests {
     fn test_redis() -> fred::clients::RedisClient {
         let config = fred::types::RedisConfig::default();
         fred::clients::RedisClient::new(config, None, None, None)
+    }
+
+    /// Patreon disabled by default — tests that don't exercise Patreon
+    /// linking get a no-op state so `mint_access_token` simply doesn't emit
+    /// the `arkavo_patreon` claim.
+    fn test_patreon_state() -> crate::patreon::PatreonState {
+        crate::patreon::PatreonState::new(None, None, test_redis())
     }
 
     #[tokio::test]
@@ -2181,6 +2247,7 @@ mod tests {
                     "handles".to_string(),
                     "device_bindings".to_string(),
                     "identity_links".to_string(),
+                    "patreon_tokens".to_string(),
                 )
                 .await
                 .unwrap(),
@@ -2276,6 +2343,7 @@ mod tests {
                     "handles".to_string(),
                     "device_bindings".to_string(),
                     "identity_links".to_string(),
+                    "patreon_tokens".to_string(),
                 )
                 .await
                 .unwrap(),
@@ -2323,8 +2391,15 @@ mod tests {
         };
 
         let headers = HeaderMap::new();
-        let resp =
-            handle_refresh_token_grant(app_state, oidc, refresh_store.clone(), headers, form).await;
+        let resp = handle_refresh_token_grant(
+            app_state,
+            oidc,
+            refresh_store.clone(),
+            test_patreon_state(),
+            headers,
+            form,
+        )
+        .await;
         assert_eq!(resp.status(), StatusCode::OK);
 
         let body_bytes = axum::body::to_bytes(resp.into_body(), 64 * 1024)

--- a/src/patreon.rs
+++ b/src/patreon.rs
@@ -668,12 +668,13 @@ struct PatreonTokenResponse {
     pub token_type: String,
 }
 
-/// Classify a non-success Patreon token-endpoint response. Client errors (4xx)
-/// mean the *caller's* `code`/`redirect_uri` was bad → surface a 400. Server
-/// errors / unexpected statuses are Patreon's fault → 502 with diagnostics for
-/// the logs only.
+/// Classify a non-success Patreon token-endpoint response. Only a 400 reflects
+/// a bad `code`/`redirect_uri` (the caller's fault) → InvalidGrant. Other 4xx
+/// are *not* the caller's problem — 429 means Patreon is rate-limiting us,
+/// 401/403 mean our client credentials are misconfigured — so they route
+/// through `Api` (502) with diagnostics preserved for the logs.
 fn token_exchange_error(status: reqwest::StatusCode, body: &str) -> PatreonError {
-    if status.is_client_error() {
+    if status == reqwest::StatusCode::BAD_REQUEST {
         PatreonError::InvalidGrant
     } else {
         PatreonError::Api(format!(
@@ -1066,40 +1067,76 @@ pub async fn materialize_for_user(
 
     let (snap, refreshed) = match materialize_from_link(state, &link).await {
         Ok(v) => v,
-        Err(e) => {
+        Err(failure) => {
             warn!(
                 "Patreon materialization failed for user {}: {} — failing closed (no claim)",
-                user_id, e
+                user_id, failure.error
             );
+            // Even on failure, a refresh may have succeeded before the retry
+            // fetch broke. Patreon consumed the old refresh token the moment
+            // the refresh went through — persisting the rotated link is the
+            // only way the next mint can refresh at all.
+            persist_rotated_tokens(app_state, user_id, failure.refreshed).await;
             return None;
         }
     };
 
-    // If the access token was refreshed during materialization, persist the
-    // rotated tokens. Best-effort: a persist failure doesn't fail the mint (we
-    // already have the memberships) — the next mint simply refreshes again.
-    if let Some(new_link) = refreshed {
-        match app_state.db_store.put_patreon_link(&new_link).await {
-            Ok(()) => debug!("Persisted refreshed Patreon tokens for user {}", user_id),
-            Err(e) => warn!(
-                "Failed to persist refreshed Patreon tokens for user {}: {} — will refresh again next mint",
-                user_id, e
-            ),
-        }
-    }
+    persist_rotated_tokens(app_state, user_id, refreshed).await;
 
     state.cache.put(user_id, &snap).await;
     Some(snap)
 }
 
+/// Persist a rotated Patreon token bundle, if one was produced. Best-effort:
+/// a persist failure doesn't fail the mint, but it does mean the DB still
+/// holds the already-consumed refresh token — the next refresh attempt will
+/// be rejected by Patreon and the user fails closed until they re-link, so
+/// the failure is logged loudly.
+async fn persist_rotated_tokens(
+    app_state: &AppState,
+    user_id: Uuid,
+    refreshed: Option<PatreonLink>,
+) {
+    let Some(new_link) = refreshed else { return };
+    match app_state.db_store.put_patreon_link(&new_link).await {
+        Ok(()) => debug!("Persisted refreshed Patreon tokens for user {}", user_id),
+        Err(e) => warn!(
+            "Failed to persist refreshed Patreon tokens for user {}: {} — stored refresh token is \
+             already consumed; subsequent refreshes will fail until the user re-links",
+            user_id, e
+        ),
+    }
+}
+
+/// A materialization failure that may still carry a successfully rotated
+/// token bundle. Patreon consumes the old refresh token the moment a refresh
+/// succeeds, so if the post-refresh retry fetch then fails, the rotated link
+/// MUST still reach the caller for persistence — otherwise the DB keeps the
+/// dead refresh token and the user is stuck fail-closed until they re-link.
+#[derive(Debug)]
+struct MaterializeFailure {
+    error: PatreonError,
+    refreshed: Option<PatreonLink>,
+}
+
+impl From<PatreonError> for MaterializeFailure {
+    fn from(error: PatreonError) -> Self {
+        Self {
+            error,
+            refreshed: None,
+        }
+    }
+}
+
 /// Produce the membership snapshot for a link. The returned `Option<PatreonLink>`
 /// is `Some` iff a token refresh happened and the caller should persist the
 /// rotated tokens. Any unrecoverable failure propagates — the caller fails
-/// closed (omits the claim, doesn't cache).
+/// closed (omits the claim, doesn't cache) — but the failure still carries a
+/// rotated link when the refresh itself succeeded.
 async fn materialize_from_link(
     state: &PatreonState,
     link: &PatreonLink,
-) -> Result<(ArkavoPatreon, Option<PatreonLink>), PatreonError> {
+) -> Result<(ArkavoPatreon, Option<PatreonLink>), MaterializeFailure> {
     let sealer = state.sealer.as_ref().ok_or(PatreonError::NotConfigured)?;
 
     let access_plain = sealer
@@ -1153,19 +1190,21 @@ async fn materialize_from_link(
 /// Fetch consumer memberships, transparently refreshing the access token once
 /// if Patreon returns 401 (token expired/revoked). On refresh, returns the
 /// rotated [`PatreonLink`] so the caller can persist it; the retry fetch is
-/// authoritative (a second 401 propagates rather than looping).
+/// authoritative (a second 401 propagates rather than looping). If the retry
+/// fails after a successful refresh, the error carries the rotated link — the
+/// old refresh token is already consumed, so the caller must still persist.
 ///
 /// Concurrency note: two simultaneous mints for the same user can both refresh.
 /// Patreon rotates the refresh token on use, so the slower refresh may fail (it
 /// reused an already-consumed refresh token) — that mint just fails closed for
 /// that request, and persistence is last-writer-wins. Acceptable for the read
 /// path; fully serializing refreshes (distributed lock / conditional update) is
-/// intentionally out of scope here.
+/// intentionally out of scope here (tracked in #36).
 async fn fetch_memberships_with_refresh(
     state: &PatreonState,
     link: &PatreonLink,
     access_token: &str,
-) -> Result<(Vec<ArkavoPatreonMembership>, Option<PatreonLink>), PatreonError> {
+) -> Result<(Vec<ArkavoPatreonMembership>, Option<PatreonLink>), MaterializeFailure> {
     match fetch_consumer_memberships(&state.http, access_token, &state.identity_url).await {
         Ok(m) => Ok((m, None)),
         Err(PatreonError::Unauthorized) => {
@@ -1204,16 +1243,24 @@ async fn fetch_memberships_with_refresh(
                 merge_refreshed_link(link, &new_tokens, sealed_access, sealed_refresh, now);
 
             // Retry once with the new access token. A failure here propagates
-            // (fail-closed) rather than triggering a second refresh.
-            let memberships = fetch_consumer_memberships(
+            // (fail-closed) rather than triggering a second refresh — but it
+            // carries the rotated link: the refresh already consumed the old
+            // refresh token, so dropping the new one would strand the user.
+            match fetch_consumer_memberships(
                 &state.http,
                 &new_tokens.access_token,
                 &state.identity_url,
             )
-            .await?;
-            Ok((memberships, Some(refreshed_link)))
+            .await
+            {
+                Ok(memberships) => Ok((memberships, Some(refreshed_link))),
+                Err(error) => Err(MaterializeFailure {
+                    error,
+                    refreshed: Some(refreshed_link),
+                }),
+            }
         }
-        Err(e) => Err(e),
+        Err(e) => Err(e.into()),
     }
 }
 
@@ -1489,6 +1536,26 @@ mod tests {
     }
 
     #[test]
+    fn token_exchange_non_400_client_errors_are_upstream_failures() {
+        // 429 = Patreon rate-limiting *us*; 401/403 = our client credentials
+        // are misconfigured. None of these are the caller's fault — they must
+        // not masquerade as InvalidGrant (which invites the client to retry
+        // with a fresh code, amplifying load) and must keep diagnostics.
+        for status in [
+            reqwest::StatusCode::TOO_MANY_REQUESTS,
+            reqwest::StatusCode::UNAUTHORIZED,
+            reqwest::StatusCode::FORBIDDEN,
+        ] {
+            let err = token_exchange_error(status, "details");
+            assert!(
+                matches!(err, PatreonError::Api(ref m) if m.contains(status.as_str())),
+                "{status} should map to Api with diagnostics, got: {err:?}"
+            );
+            assert_eq!(err.into_response().status(), StatusCode::BAD_GATEWAY);
+        }
+    }
+
+    #[test]
     fn truncate_respects_char_boundaries() {
         let s = "αβγδ"; // 4 chars, 8 bytes
         assert_eq!(truncate(s, 100), s);
@@ -1748,10 +1815,11 @@ mod tests {
     /// Minimal localhost Patreon stand-in. Dispatches on method + bearer token:
     /// - POST (token endpoint)            → 200, rotated tokens (new-access/new-refresh)
     /// - GET  with `Bearer old-access`    → 401 (token expired)
-    /// - GET  with `Bearer new-access`    → 200, one active membership
+    /// - GET  with `Bearer new-access`    → 200, one active membership when
+    ///   `retry_ok`, else 500 (post-refresh retry fetch fails)
     ///
     /// Returns `(token_url, identity_url)` pointing at the spawned server.
-    async fn spawn_patreon_mock() -> (String, String) {
+    async fn spawn_patreon_mock(retry_ok: bool) -> (String, String) {
         use tokio::io::{AsyncReadExt, AsyncWriteExt};
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
@@ -1777,11 +1845,13 @@ mod tests {
                         )
                     } else if has_old {
                         ("HTTP/1.1 401 Unauthorized", String::new())
-                    } else {
+                    } else if retry_ok {
                         (
                             "HTTP/1.1 200 OK",
                             r#"{"data":{"id":"p-1"},"included":[{"type":"member","id":"m1","attributes":{"patron_status":"active_patron"},"relationships":{"campaign":{"data":{"id":"camp-1"}},"currently_entitled_tiers":{"data":[{"id":"tier-gold"}]}}}]}"#.to_string(),
                         )
+                    } else {
+                        ("HTTP/1.1 500 Internal Server Error", String::new())
                     };
                     let resp = format!(
                         "{status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
@@ -1799,7 +1869,7 @@ mod tests {
     #[tokio::test]
     async fn consumer_membership_refreshes_on_401_and_retries() {
         // End-to-end: stale access token → 401 → refresh → retry → memberships.
-        let (token_url, identity_url) = spawn_patreon_mock().await;
+        let (token_url, identity_url) = spawn_patreon_mock(true).await;
         let sealer = TokenSealer::Plaintext;
         let link = consumer_link_with_token(&sealer, b"old-access").await;
         let redis =
@@ -1843,6 +1913,53 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(opened, b"new-access");
+    }
+
+    #[tokio::test]
+    async fn refresh_survives_failed_retry_fetch() {
+        // 401 → refresh succeeds (old refresh token now consumed by Patreon)
+        // → retry fetch 500s. The materialization must fail closed AND hand
+        // back the rotated link for persistence — dropping it would leave the
+        // dead refresh token in the DB and strand the user until re-link.
+        let (token_url, identity_url) = spawn_patreon_mock(false).await;
+        let sealer = TokenSealer::Plaintext;
+        let link = consumer_link_with_token(&sealer, b"old-access").await;
+        let redis =
+            fred::clients::RedisClient::new(fred::types::RedisConfig::default(), None, None, None);
+        let state = PatreonState {
+            oauth: Some(PatreonOAuthConfig {
+                client_id: "c".into(),
+                client_secret: "s".into(),
+                redirect_uris: vec!["https://x/cb".into()],
+            }),
+            sealer: Some(sealer.clone()),
+            http: reqwest::Client::new(),
+            cache: MembershipCache::new(redis),
+            token_url,
+            identity_url,
+        };
+
+        let failure = materialize_from_link(&state, &link)
+            .await
+            .expect_err("retry 500 must fail the materialization");
+        assert!(
+            matches!(failure.error, PatreonError::Api(_)),
+            "expected Api error from the failed retry, got: {:?}",
+            failure.error
+        );
+
+        let new_link = failure
+            .refreshed
+            .expect("rotated link must survive the failed retry fetch");
+        let opened = sealer
+            .open(&SealedToken {
+                wrapped_dek: new_link.wrapped_dek.clone(),
+                nonce: new_link.refresh_token_nonce.clone(),
+                ciphertext: new_link.refresh_token_ct.clone(),
+            })
+            .await
+            .unwrap();
+        assert_eq!(opened, b"new-refresh");
     }
 
     #[tokio::test]

--- a/src/patreon.rs
+++ b/src/patreon.rs
@@ -1,0 +1,1399 @@
+// `Key::<Aes256Gcm>::from_slice` is the documented constructor on the
+// aes-gcm 0.10.x release line but fires a transitive deprecation warning
+// from generic-array 0.x. Tracked upstream; until aes-gcm rolls forward to
+// generic-array 1.x we suppress at the module level instead of polluting
+// each call site.
+#![allow(deprecated)]
+
+//! Patreon identity linking + membership materialization.
+//!
+//! This module mirrors the [`apple_signin`](crate::apple_signin) linking
+//! pattern for Patreon as an upstream identity / entitlement source. Unlike
+//! Apple, Patreon does not issue an id_token; it uses OAuth2 authorization
+//! code flow. The end result is the same shape: the verified Patreon
+//! identifier is bound to an arkavo user in the `identity_links` table
+//! (per the Apple linking contract — minimum-PII, one-Patreon-account-to-one
+//! arkavo-user enforced by a conditional put).
+//!
+//! # Architecture
+//!
+//! - **Linking** (`POST /oauth/patreon/link`): auth-required handler that
+//!   accepts an OAuth `code` returned from `www.patreon.com/oauth2/authorize`,
+//!   exchanges it for Patreon access/refresh tokens server-side, fetches
+//!   `/api/oauth2/v2/identity` to discover the Patreon user id (and, for
+//!   creators, their campaign id), then persists two rows:
+//!
+//!   1. `identity_links`: `patreon#<patreon_user_id> → arkavo_user_id`
+//!      conditional put — provides per-Patreon-account uniqueness and an
+//!      audit-traceable join key. Same shape as Apple linking.
+//!   2. `patreon_tokens`: the encrypted access + refresh tokens keyed by
+//!      arkavo `user_id`, plus the discovered `patreon_user_id` and (creator
+//!      only) `campaign_id`.
+//!
+//! - **Token sealing**: KMS envelope encryption. Tokens are AES-256-GCM
+//!   encrypted under a fresh per-row 256-bit DEK; the DEK itself is wrapped
+//!   by an operator-configured KMS key. This means a DynamoDB compromise
+//!   alone is insufficient to recover the Patreon tokens — an attacker also
+//!   needs `kms:Decrypt` permission on the key.
+//!
+//! - **Membership materialization**: there is no separate
+//!   `/entitlements/...` endpoint surface. Patreon membership and tier
+//!   claims are emitted *only* inside the OIDC access_token CWT, via
+//!   [`materialize_for_user`]. The materialization is cached in Redis (with
+//!   a fallback in-memory map) for [`crate::constants::PATREON_CACHE_TTL_SECONDS`]
+//!   so we don't hammer Patreon on every token mint; the cached snapshot
+//!   carries `verified_at` / `cache_expires_at` so RPs can detect stale data.
+//!
+//! # Failure posture
+//!
+//! Fail-closed for membership: when Patreon is unreachable, the linked-user
+//! lookup fails, or the cached snapshot is past `cache_expires_at`, the
+//! mint path omits the `arkavo_patreon` claim entirely. Downstream KAS /
+//! policy enforcers must treat absence of the claim as "no entitlement",
+//! per the architecture statement "Patreon proves membership."
+//!
+//! # No new endpoint surface beyond linking
+//!
+//! The deliberate design constraint here is that the *only* new external
+//! endpoint is `POST /oauth/patreon/link` (mirroring `POST /oauth/apple/link`).
+//! Status, entitlement, and membership-check endpoints are intentionally
+//! omitted — relying parties read everything they need from the
+//! access_token CWT.
+
+use crate::AppState;
+use crate::constants::{
+    PATREON_CACHE_TTL_SECONDS, PATREON_CAMPAIGN_MEMBERS_URL_TEMPLATE, PATREON_IDENTITY_URL,
+    PATREON_TOKEN_URL,
+};
+use crate::cwt::{ArkavoPatreon, ArkavoPatreonMembership};
+use aes_gcm::aead::{Aead, AeadCore, KeyInit, OsRng};
+use aes_gcm::{Aes256Gcm, Key, Nonce};
+use aws_sdk_kms::primitives::Blob;
+use axum::Json;
+use axum::extract::Extension;
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Response};
+use chrono::Utc;
+use fred::interfaces::{ClientLike, KeysInterface};
+use log::{debug, error, info, warn};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::env;
+use std::sync::{Arc, Mutex};
+use thiserror::Error;
+use uuid::Uuid;
+
+/// Patreon OAuth client configuration. Loaded once at startup from env vars.
+///
+/// Empty/missing config disables every Patreon code path silently — link
+/// handler returns 503, membership materialization is skipped. This lets
+/// non-Patreon deployments run without forcing operators to set Patreon
+/// credentials.
+#[derive(Debug, Clone)]
+pub struct PatreonOAuthConfig {
+    pub client_id: String,
+    pub client_secret: String,
+    /// Allow-list of permitted redirect URIs. Must contain whatever the
+    /// client used at `https://www.patreon.com/oauth2/authorize`. Comma-
+    /// separated in `PATREON_REDIRECT_URIS`.
+    pub redirect_uris: Vec<String>,
+}
+
+impl PatreonOAuthConfig {
+    pub fn from_env() -> Option<Self> {
+        let client_id = env::var("PATREON_CLIENT_ID")
+            .ok()
+            .filter(|s| !s.is_empty())?;
+        let client_secret = env::var("PATREON_CLIENT_SECRET")
+            .ok()
+            .filter(|s| !s.is_empty())?;
+        let redirect_uris: Vec<String> = env::var("PATREON_REDIRECT_URIS")
+            .ok()
+            .map(|raw| {
+                raw.split(',')
+                    .map(|s| s.trim().to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect()
+            })
+            .unwrap_or_default();
+        if redirect_uris.is_empty() {
+            warn!(
+                "PATREON_CLIENT_ID is set but PATREON_REDIRECT_URIS is empty — \
+                 /oauth/patreon/link will reject all callbacks"
+            );
+            return None;
+        }
+        Some(Self {
+            client_id,
+            client_secret,
+            redirect_uris,
+        })
+    }
+}
+
+/// KMS envelope sealer for Patreon access/refresh tokens.
+///
+/// `Kms` is the production variant. In tests we substitute a plaintext sealer
+/// that still produces valid-shape `wrapped_dek` / `nonce` / `ct` bytes so
+/// the surrounding DynamoDB CRUD can be exercised without a real KMS call.
+#[derive(Clone)]
+pub enum TokenSealer {
+    Kms {
+        client: aws_sdk_kms::Client,
+        key_id: String,
+    },
+    #[cfg(test)]
+    Plaintext, // ONLY for tests; stores DEK alongside ciphertext, no wrapping.
+}
+
+impl std::fmt::Debug for TokenSealer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Kms { key_id, .. } => f.debug_struct("Kms").field("key_id", key_id).finish(),
+            #[cfg(test)]
+            Self::Plaintext => write!(f, "Plaintext"),
+        }
+    }
+}
+
+/// One sealed plaintext: (wrapped DEK, nonce, ciphertext).
+#[derive(Debug, Clone)]
+pub struct SealedToken {
+    pub wrapped_dek: Vec<u8>,
+    pub nonce: Vec<u8>,
+    pub ciphertext: Vec<u8>,
+}
+
+impl TokenSealer {
+    /// Seal a single plaintext token. Generates a fresh DEK so multiple
+    /// tokens stored together don't share a DEK + nonce reuse risk.
+    pub async fn seal(&self, plaintext: &[u8]) -> Result<SealedToken, PatreonError> {
+        match self {
+            TokenSealer::Kms { client, key_id } => {
+                let mut dek = [0u8; 32];
+                use aes_gcm::aead::rand_core::RngCore;
+                OsRng.fill_bytes(&mut dek);
+
+                let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(&dek));
+                let nonce_bytes = Aes256Gcm::generate_nonce(&mut OsRng);
+                let ciphertext = cipher
+                    .encrypt(&nonce_bytes, plaintext)
+                    .map_err(|_| PatreonError::Crypto("AES-256-GCM encrypt failed".into()))?;
+
+                let wrap_resp = client
+                    .encrypt()
+                    .key_id(key_id)
+                    .plaintext(Blob::new(dek.to_vec()))
+                    .send()
+                    .await
+                    .map_err(|e| PatreonError::Kms(format!("Encrypt: {}", e)))?;
+                let wrapped_dek = wrap_resp
+                    .ciphertext_blob
+                    .ok_or_else(|| PatreonError::Kms("missing ciphertext_blob".into()))?
+                    .into_inner();
+
+                // Zeroize the DEK eagerly; it has done its job. (Best-effort
+                // overwrite — `dek` is a stack array, no allocation tracking.)
+                for b in dek.iter_mut() {
+                    *b = 0;
+                }
+
+                Ok(SealedToken {
+                    wrapped_dek,
+                    nonce: nonce_bytes.to_vec(),
+                    ciphertext,
+                })
+            }
+            #[cfg(test)]
+            TokenSealer::Plaintext => {
+                let dek = [0u8; 32];
+                let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(&dek));
+                let nonce_bytes = Aes256Gcm::generate_nonce(&mut OsRng);
+                let ciphertext = cipher
+                    .encrypt(&nonce_bytes, plaintext)
+                    .map_err(|_| PatreonError::Crypto("test sealer encrypt".into()))?;
+                // "Wrapped" DEK is the zero key itself so open() can recover it.
+                Ok(SealedToken {
+                    wrapped_dek: dek.to_vec(),
+                    nonce: nonce_bytes.to_vec(),
+                    ciphertext,
+                })
+            }
+        }
+    }
+
+    pub async fn open(&self, sealed: &SealedToken) -> Result<Vec<u8>, PatreonError> {
+        let dek = match self {
+            TokenSealer::Kms { client, .. } => {
+                let resp = client
+                    .decrypt()
+                    .ciphertext_blob(Blob::new(sealed.wrapped_dek.clone()))
+                    .send()
+                    .await
+                    .map_err(|e| PatreonError::Kms(format!("Decrypt: {}", e)))?;
+                let bytes = resp
+                    .plaintext
+                    .ok_or_else(|| PatreonError::Kms("missing plaintext".into()))?
+                    .into_inner();
+                if bytes.len() != 32 {
+                    return Err(PatreonError::Crypto(format!(
+                        "DEK length {} != 32",
+                        bytes.len()
+                    )));
+                }
+                let mut dek = [0u8; 32];
+                dek.copy_from_slice(&bytes);
+                dek
+            }
+            #[cfg(test)]
+            TokenSealer::Plaintext => {
+                if sealed.wrapped_dek.len() != 32 {
+                    return Err(PatreonError::Crypto("test DEK len".into()));
+                }
+                let mut dek = [0u8; 32];
+                dek.copy_from_slice(&sealed.wrapped_dek);
+                dek
+            }
+        };
+        let cipher = Aes256Gcm::new(Key::<Aes256Gcm>::from_slice(&dek));
+        if sealed.nonce.len() != 12 {
+            return Err(PatreonError::Crypto("nonce length != 12".into()));
+        }
+        let nonce = Nonce::from_slice(&sealed.nonce);
+        cipher
+            .decrypt(nonce, sealed.ciphertext.as_slice())
+            .map_err(|_| PatreonError::Crypto("AES-256-GCM decrypt failed".into()))
+    }
+}
+
+/// Build the [`TokenSealer`] from env (`PATREON_KMS_KEY_ID`) + an existing
+/// AWS SDK shared config. Returns `None` if Patreon support is disabled
+/// (no `PATREON_KMS_KEY_ID`).
+pub async fn build_kms_sealer() -> Option<TokenSealer> {
+    let key_id = env::var("PATREON_KMS_KEY_ID")
+        .ok()
+        .filter(|s| !s.is_empty())?;
+    let config = aws_config::load_defaults(aws_config::BehaviorVersion::latest()).await;
+    let client = aws_sdk_kms::Client::new(&config);
+    Some(TokenSealer::Kms { client, key_id })
+}
+
+/// Holder for Patreon runtime state. Carried as an Axum `Extension` so all
+/// patreon handlers + the OIDC mint enrichment can find it.
+#[derive(Clone)]
+pub struct PatreonState {
+    pub oauth: Option<PatreonOAuthConfig>,
+    pub sealer: Option<TokenSealer>,
+    pub http: reqwest::Client,
+    pub cache: MembershipCache,
+}
+
+impl PatreonState {
+    pub fn new(
+        oauth: Option<PatreonOAuthConfig>,
+        sealer: Option<TokenSealer>,
+        redis: fred::clients::RedisClient,
+    ) -> Self {
+        Self {
+            oauth,
+            sealer,
+            http: reqwest::Client::builder()
+                .user_agent("authnz-rs/0.6")
+                .timeout(std::time::Duration::from_secs(10))
+                .build()
+                .unwrap_or_else(|_| reqwest::Client::new()),
+            cache: MembershipCache::new(redis),
+        }
+    }
+
+    fn is_enabled(&self) -> bool {
+        self.oauth.is_some() && self.sealer.is_some()
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum PatreonError {
+    #[error("Patreon integration is not configured on this server")]
+    NotConfigured,
+    #[error("redirect_uri is not in the operator-configured allow list")]
+    InvalidRedirectUri,
+    #[error("role must be \"creator\" or \"consumer\"")]
+    InvalidRole,
+    #[error("missing or invalid X-Auth-Token")]
+    MissingAuth,
+    #[error("Patreon API error: {0}")]
+    Api(String),
+    #[error("KMS error: {0}")]
+    Kms(String),
+    #[error("Crypto error: {0}")]
+    Crypto(String),
+    #[error("DynamoDB error: {0}")]
+    Db(String),
+    #[error("Patreon identity already linked to a different arkavo user")]
+    LinkConflict,
+    #[allow(dead_code)]
+    #[error("Internal error: {0}")]
+    Internal(String),
+}
+
+impl IntoResponse for PatreonError {
+    fn into_response(self) -> Response {
+        let status = match &self {
+            PatreonError::NotConfigured => StatusCode::SERVICE_UNAVAILABLE,
+            PatreonError::InvalidRedirectUri | PatreonError::InvalidRole => StatusCode::BAD_REQUEST,
+            PatreonError::MissingAuth => StatusCode::UNAUTHORIZED,
+            PatreonError::Api(_) => StatusCode::BAD_GATEWAY,
+            PatreonError::LinkConflict => StatusCode::CONFLICT,
+            PatreonError::Kms(_)
+            | PatreonError::Crypto(_)
+            | PatreonError::Db(_)
+            | PatreonError::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        };
+        (status, self.to_string()).into_response()
+    }
+}
+
+/// Persisted Patreon token bundle for an arkavo user.
+///
+/// Keyed by `user_id` in DynamoDB (`patreon_tokens` table). The token bytes
+/// are KMS-envelope-encrypted; the same `wrapped_dek` is reused for both
+/// access and refresh tokens (one DEK per row, distinct GCM nonces per
+/// token — never reuse nonce + key).
+#[derive(Debug, Clone)]
+pub struct PatreonLink {
+    pub user_id: Uuid,
+    /// `creator` or `consumer`.
+    pub role: String,
+    pub patreon_user_id: String,
+    pub campaign_id: Option<String>,
+    pub scopes: String,
+    pub access_token_ct: Vec<u8>,
+    pub access_token_nonce: Vec<u8>,
+    pub refresh_token_ct: Vec<u8>,
+    pub refresh_token_nonce: Vec<u8>,
+    pub wrapped_dek: Vec<u8>,
+    pub token_expires_at: i64,
+    pub linked_at: i64,
+}
+
+// --------- Linking endpoint ---------
+
+#[derive(Debug, Deserialize)]
+pub struct LinkRequest {
+    /// OAuth authorization code returned by Patreon to the client's redirect
+    /// URI.
+    pub code: String,
+    /// Redirect URI used during the authorize step. Must match an entry in
+    /// `PATREON_REDIRECT_URIS`.
+    pub redirect_uri: String,
+    /// `creator` or `consumer`. Determines which scopes are persisted and
+    /// whether `campaign_id` discovery runs.
+    pub role: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct LinkResponse {
+    pub patreon_user_id: String,
+    pub role: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub campaign_id: Option<String>,
+}
+
+/// `POST /oauth/patreon/link`
+///
+/// Auth-required. Mirrors `POST /oauth/apple/link`:
+/// - Caller must present a valid Arkavo CWT in `X-Auth-Token` (this is the
+///   arkavo user_id that the Patreon identity will be bound to).
+/// - On success, writes both `identity_links` (patreon#sub → user_id,
+///   conditional put for uniqueness) and `patreon_tokens` (encrypted tokens
+///   keyed by user_id).
+/// - 200 on success (or idempotent re-link to the same user).
+/// - 409 if this Patreon account is already linked to a *different* arkavo
+///   user (cross-account-hijack guard).
+/// - 502 if Patreon's token / identity endpoint rejects the exchange.
+/// - 503 if Patreon support is not configured on this deployment.
+pub async fn patreon_link_handler(
+    Extension(app_state): Extension<AppState>,
+    Extension(state): Extension<PatreonState>,
+    headers: HeaderMap,
+    Json(req): Json<LinkRequest>,
+) -> Response {
+    let client_ip = client_ip_from_headers(&headers);
+
+    let user_id = match extract_authenticated_user_id(&app_state, &headers) {
+        Ok(id) => id,
+        Err(e) => return e.into_response(),
+    };
+
+    if !state.is_enabled() {
+        return PatreonError::NotConfigured.into_response();
+    }
+    let oauth = state.oauth.as_ref().unwrap();
+    let sealer = state.sealer.as_ref().unwrap();
+
+    let role = match req.role.as_str() {
+        "creator" | "consumer" => req.role.clone(),
+        _ => return PatreonError::InvalidRole.into_response(),
+    };
+
+    if !oauth.redirect_uris.iter().any(|u| u == &req.redirect_uri) {
+        return PatreonError::InvalidRedirectUri.into_response();
+    }
+
+    // 1. Exchange the code for tokens.
+    let tokens =
+        match exchange_code_for_tokens(&state.http, oauth, &req.code, &req.redirect_uri).await {
+            Ok(t) => t,
+            Err(e) => {
+                warn!("Patreon code exchange failed: {}", e);
+                return e.into_response();
+            }
+        };
+
+    // 2. Discover patreon_user_id (+ campaign_id for creators).
+    let (patreon_user_id, campaign_id) = match fetch_identity(
+        &state.http,
+        &tokens.access_token,
+        role.as_str() == "creator",
+    )
+    .await
+    {
+        Ok(v) => v,
+        Err(e) => {
+            warn!("Patreon identity fetch failed: {}", e);
+            return e.into_response();
+        }
+    };
+
+    // 3. Persist the link. identity_links first (uniqueness check), then
+    //    patreon_tokens. Order matters: identity_links is the per-Patreon-
+    //    account guard; only after we know we own the binding do we encrypt
+    //    and store the tokens.
+    let sub_prefix = subject_prefix(&patreon_user_id);
+    match app_state
+        .db_store
+        .link_identity(user_id, "patreon", &patreon_user_id)
+        .await
+    {
+        Ok(()) => info!(
+            "audit identity_link outcome=linked user_id={} provider=patreon role={} subject_prefix={} client_ip={}",
+            user_id, role, sub_prefix, client_ip
+        ),
+        Err(crate::db::DynamoDBError::LinkConflict) => {
+            warn!(
+                "audit identity_link outcome=conflict user_id={} provider=patreon role={} subject_prefix={} client_ip={}",
+                user_id, role, sub_prefix, client_ip
+            );
+            return PatreonError::LinkConflict.into_response();
+        }
+        Err(e) => {
+            error!("Failed to write identity_link for Patreon: {}", e);
+            return PatreonError::Db("identity_link_write_failed".into()).into_response();
+        }
+    }
+
+    // Encrypt both tokens. Per the design note above, the access and refresh
+    // ciphertexts get their own nonces but share a DEK to keep storage small.
+    let now = Utc::now().timestamp();
+    let token_expires_at = now + tokens.expires_in;
+
+    let sealed_access = match sealer.seal(tokens.access_token.as_bytes()).await {
+        Ok(s) => s,
+        Err(e) => return e.into_response(),
+    };
+    let sealed_refresh = match seal_under_existing_dek(
+        sealer,
+        &sealed_access.wrapped_dek,
+        tokens.refresh_token.as_bytes(),
+    )
+    .await
+    {
+        Ok(s) => s,
+        Err(e) => return e.into_response(),
+    };
+
+    let link = PatreonLink {
+        user_id,
+        role: role.clone(),
+        patreon_user_id: patreon_user_id.clone(),
+        campaign_id: campaign_id.clone(),
+        scopes: tokens.scope.clone(),
+        access_token_ct: sealed_access.ciphertext,
+        access_token_nonce: sealed_access.nonce,
+        refresh_token_ct: sealed_refresh.ciphertext,
+        refresh_token_nonce: sealed_refresh.nonce,
+        wrapped_dek: sealed_access.wrapped_dek,
+        token_expires_at,
+        linked_at: now,
+    };
+
+    if let Err(e) = app_state.db_store.put_patreon_link(&link).await {
+        error!("Failed to persist patreon_tokens row: {}", e);
+        return PatreonError::Db("patreon_tokens_write_failed".into()).into_response();
+    }
+
+    // Invalidate any cached materialization so the next access-token mint
+    // picks up the freshly-linked memberships.
+    state.cache.invalidate(user_id).await;
+
+    Json(LinkResponse {
+        patreon_user_id,
+        role,
+        campaign_id,
+    })
+    .into_response()
+}
+
+/// Seal a second plaintext under the same DEK as a previously-sealed token.
+///
+/// Used so the access + refresh tokens in a row share one wrapped DEK
+/// (saving a second KMS round-trip per link). Distinct GCM nonces are
+/// generated per call, so the (key, nonce) pair is never reused.
+async fn seal_under_existing_dek(
+    sealer: &TokenSealer,
+    wrapped_dek: &[u8],
+    plaintext: &[u8],
+) -> Result<SealedToken, PatreonError> {
+    // Recover the DEK by asking the sealer to open just the wrapped DEK
+    // (using an empty ciphertext is not portable; instead we round-trip a
+    // throwaway plaintext to get back the DEK).
+    //
+    // Implementation: re-decrypt the wrapped_dek directly.
+    let dek = match sealer {
+        TokenSealer::Kms { client, .. } => {
+            let resp = client
+                .decrypt()
+                .ciphertext_blob(Blob::new(wrapped_dek.to_vec()))
+                .send()
+                .await
+                .map_err(|e| PatreonError::Kms(format!("Decrypt: {}", e)))?;
+            resp.plaintext
+                .ok_or_else(|| PatreonError::Kms("missing plaintext".into()))?
+                .into_inner()
+        }
+        #[cfg(test)]
+        TokenSealer::Plaintext => wrapped_dek.to_vec(),
+    };
+    if dek.len() != 32 {
+        return Err(PatreonError::Crypto("recovered DEK len != 32".into()));
+    }
+    let key = Key::<Aes256Gcm>::from_slice(&dek);
+    let cipher = Aes256Gcm::new(key);
+    let nonce_bytes = Aes256Gcm::generate_nonce(&mut OsRng);
+    let ciphertext = cipher
+        .encrypt(&nonce_bytes, plaintext)
+        .map_err(|_| PatreonError::Crypto("AES-256-GCM encrypt failed".into()))?;
+    Ok(SealedToken {
+        wrapped_dek: wrapped_dek.to_vec(),
+        nonce: nonce_bytes.to_vec(),
+        ciphertext,
+    })
+}
+
+// --------- Patreon HTTP client ---------
+
+#[derive(Debug, Clone, Deserialize)]
+struct PatreonTokenResponse {
+    pub access_token: String,
+    pub refresh_token: String,
+    pub expires_in: i64,
+    #[serde(default)]
+    pub scope: String,
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub token_type: String,
+}
+
+async fn exchange_code_for_tokens(
+    http: &reqwest::Client,
+    oauth: &PatreonOAuthConfig,
+    code: &str,
+    redirect_uri: &str,
+) -> Result<PatreonTokenResponse, PatreonError> {
+    let form = [
+        ("code", code),
+        ("grant_type", "authorization_code"),
+        ("client_id", oauth.client_id.as_str()),
+        ("client_secret", oauth.client_secret.as_str()),
+        ("redirect_uri", redirect_uri),
+    ];
+    let resp = http
+        .post(PATREON_TOKEN_URL)
+        .form(&form)
+        .send()
+        .await
+        .map_err(|e| PatreonError::Api(format!("token POST: {}", e)))?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(PatreonError::Api(format!(
+            "token endpoint returned {}: {}",
+            status,
+            truncate(&body, 256)
+        )));
+    }
+    resp.json::<PatreonTokenResponse>()
+        .await
+        .map_err(|e| PatreonError::Api(format!("token JSON parse: {}", e)))
+}
+
+/// Refresh a Patreon access token using its refresh token. Wired through to
+/// `materialize_from_link` in a follow-up change so a stale access token
+/// triggers refresh-and-persist on the access_token mint path; today the
+/// mint path just serves an empty membership snapshot when Patreon returns
+/// 401. The helper itself is correct, the integration is the deferred piece.
+#[allow(dead_code)]
+async fn refresh_access_token(
+    http: &reqwest::Client,
+    oauth: &PatreonOAuthConfig,
+    refresh_token: &str,
+) -> Result<PatreonTokenResponse, PatreonError> {
+    let form = [
+        ("grant_type", "refresh_token"),
+        ("refresh_token", refresh_token),
+        ("client_id", oauth.client_id.as_str()),
+        ("client_secret", oauth.client_secret.as_str()),
+    ];
+    let resp = http
+        .post(PATREON_TOKEN_URL)
+        .form(&form)
+        .send()
+        .await
+        .map_err(|e| PatreonError::Api(format!("refresh POST: {}", e)))?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(PatreonError::Api(format!(
+            "refresh endpoint returned {}: {}",
+            status,
+            truncate(&body, 256)
+        )));
+    }
+    resp.json::<PatreonTokenResponse>()
+        .await
+        .map_err(|e| PatreonError::Api(format!("refresh JSON parse: {}", e)))
+}
+
+/// Fetch the current user's Patreon identity, returning
+/// `(patreon_user_id, Option<campaign_id>)`. Campaign discovery only runs
+/// for creators (and only the first campaign is captured — multi-campaign
+/// creators must explicitly select; out of scope for MVP).
+async fn fetch_identity(
+    http: &reqwest::Client,
+    access_token: &str,
+    is_creator: bool,
+) -> Result<(String, Option<String>), PatreonError> {
+    let mut url = String::from(PATREON_IDENTITY_URL);
+    if is_creator {
+        // The `campaign` relationship is creator-only — for consumers it's
+        // empty and the extra include is harmless but wasteful.
+        url.push_str("?include=campaign&fields%5Buser%5D=email");
+    }
+    let resp = http
+        .get(&url)
+        .bearer_auth(access_token)
+        .send()
+        .await
+        .map_err(|e| PatreonError::Api(format!("identity GET: {}", e)))?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(PatreonError::Api(format!(
+            "identity endpoint returned {}: {}",
+            status,
+            truncate(&body, 256)
+        )));
+    }
+    let body: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| PatreonError::Api(format!("identity JSON parse: {}", e)))?;
+    let patreon_user_id = body
+        .get("data")
+        .and_then(|d| d.get("id"))
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| PatreonError::Api("identity response missing data.id".into()))?
+        .to_string();
+
+    let campaign_id = if is_creator {
+        find_campaign_id(&body)
+    } else {
+        None
+    };
+
+    Ok((patreon_user_id, campaign_id))
+}
+
+/// Locate the creator's owned campaign id in a Patreon `/identity` response.
+///
+/// Patreon's JSON:API response stores relationships under
+/// `data.relationships.campaign.data.id`. When the user owns no campaign
+/// the field is absent (consumer with creator role-claim → returns None
+/// rather than failing; caller can decide whether to error).
+fn find_campaign_id(body: &serde_json::Value) -> Option<String> {
+    body.get("data")?
+        .get("relationships")?
+        .get("campaign")?
+        .get("data")?
+        .get("id")?
+        .as_str()
+        .map(|s| s.to_string())
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        return s.to_string();
+    }
+    let mut end = max;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    s[..end].to_string()
+}
+
+// --------- Membership materialization (used by OIDC access_token mint) ---------
+
+#[derive(Clone)]
+pub struct MembershipCache {
+    redis: fred::clients::RedisClient,
+    local: Arc<Mutex<HashMap<String, (ArkavoPatreon, i64)>>>,
+}
+
+impl MembershipCache {
+    pub fn new(redis: fred::clients::RedisClient) -> Self {
+        Self {
+            redis,
+            local: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    fn key(user_id: Uuid) -> String {
+        format!("patreon:materialized:{}", user_id)
+    }
+
+    pub async fn get(&self, user_id: Uuid) -> Option<ArkavoPatreon> {
+        let key = Self::key(user_id);
+        if self.redis.is_connected() {
+            match self.redis.get::<Option<String>, _>(&key).await {
+                Ok(Some(s)) => match serde_json::from_str::<SerializableMaterialized>(&s) {
+                    Ok(m) => {
+                        let now = Utc::now().timestamp();
+                        if m.cache_expires_at < now {
+                            None
+                        } else {
+                            Some(m.into())
+                        }
+                    }
+                    Err(_) => None,
+                },
+                _ => None,
+            }
+        } else {
+            let mut map = self.local.lock().unwrap();
+            let now = Utc::now().timestamp();
+            map.retain(|_, (_, exp)| *exp > now);
+            map.get(&key).map(|(m, _)| m.clone())
+        }
+    }
+
+    pub async fn put(&self, user_id: Uuid, snap: &ArkavoPatreon) {
+        let key = Self::key(user_id);
+        let ser: SerializableMaterialized = snap.into();
+        if self.redis.is_connected() {
+            if let Ok(json) = serde_json::to_string(&ser) {
+                let ttl = (snap.cache_expires_at - Utc::now().timestamp()).max(1);
+                let _: Result<(), _> = self
+                    .redis
+                    .set(
+                        &key,
+                        json,
+                        Some(fred::types::Expiration::EX(ttl)),
+                        None,
+                        false,
+                    )
+                    .await;
+            }
+        } else {
+            let mut map = self.local.lock().unwrap();
+            map.insert(key, (snap.clone(), snap.cache_expires_at));
+        }
+    }
+
+    pub async fn invalidate(&self, user_id: Uuid) {
+        let key = Self::key(user_id);
+        if self.redis.is_connected() {
+            let _: Result<(), _> = self.redis.del(&key).await;
+        } else {
+            let mut map = self.local.lock().unwrap();
+            map.remove(&key);
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct SerializableMaterialized {
+    role: String,
+    patreon_user_id: String,
+    campaign_id: Option<String>,
+    memberships: Vec<SerializableMembership>,
+    verified_at: i64,
+    cache_expires_at: i64,
+}
+
+#[derive(Serialize, Deserialize)]
+struct SerializableMembership {
+    campaign_id: String,
+    patron_status: Option<String>,
+    tier_ids: Vec<String>,
+}
+
+impl From<&ArkavoPatreon> for SerializableMaterialized {
+    fn from(p: &ArkavoPatreon) -> Self {
+        Self {
+            role: p.role.clone(),
+            patreon_user_id: p.patreon_user_id.clone(),
+            campaign_id: p.campaign_id.clone(),
+            memberships: p
+                .memberships
+                .iter()
+                .map(|m| SerializableMembership {
+                    campaign_id: m.campaign_id.clone(),
+                    patron_status: m.patron_status.clone(),
+                    tier_ids: m.tier_ids.clone(),
+                })
+                .collect(),
+            verified_at: p.verified_at,
+            cache_expires_at: p.cache_expires_at,
+        }
+    }
+}
+
+impl From<SerializableMaterialized> for ArkavoPatreon {
+    fn from(s: SerializableMaterialized) -> Self {
+        Self {
+            role: s.role,
+            patreon_user_id: s.patreon_user_id,
+            campaign_id: s.campaign_id,
+            memberships: s
+                .memberships
+                .into_iter()
+                .map(|m| ArkavoPatreonMembership {
+                    campaign_id: m.campaign_id,
+                    patron_status: m.patron_status,
+                    tier_ids: m.tier_ids,
+                })
+                .collect(),
+            verified_at: s.verified_at,
+            cache_expires_at: s.cache_expires_at,
+        }
+    }
+}
+
+/// Materialize an [`ArkavoPatreon`] snapshot for the given arkavo user, for
+/// embedding in an OIDC access_token. Returns `None` if the user has no
+/// Patreon link or Patreon support is disabled; returns `None` (with a
+/// warning) if Patreon is unreachable — per the fail-closed posture, the
+/// caller must treat absence of the claim as "no entitlement".
+pub async fn materialize_for_user(
+    app_state: &AppState,
+    state: &PatreonState,
+    user_id: Uuid,
+) -> Option<ArkavoPatreon> {
+    if !state.is_enabled() {
+        return None;
+    }
+
+    if let Some(cached) = state.cache.get(user_id).await {
+        debug!("Patreon materialization cache HIT for user {}", user_id);
+        return Some(cached);
+    }
+
+    let link = match app_state.db_store.get_patreon_link(user_id).await {
+        Ok(Some(link)) => link,
+        Ok(None) => return None,
+        Err(e) => {
+            warn!(
+                "Patreon link lookup failed for user {}: {} — failing closed (no claim)",
+                user_id, e
+            );
+            return None;
+        }
+    };
+
+    let snap = match materialize_from_link(state, &link).await {
+        Ok(snap) => snap,
+        Err(e) => {
+            warn!(
+                "Patreon materialization failed for user {}: {} — failing closed (no claim)",
+                user_id, e
+            );
+            return None;
+        }
+    };
+    state.cache.put(user_id, &snap).await;
+    Some(snap)
+}
+
+async fn materialize_from_link(
+    state: &PatreonState,
+    link: &PatreonLink,
+) -> Result<ArkavoPatreon, PatreonError> {
+    let sealer = state.sealer.as_ref().ok_or(PatreonError::NotConfigured)?;
+    let oauth = state.oauth.as_ref().ok_or(PatreonError::NotConfigured)?;
+
+    let access_plain = sealer
+        .open(&SealedToken {
+            wrapped_dek: link.wrapped_dek.clone(),
+            nonce: link.access_token_nonce.clone(),
+            ciphertext: link.access_token_ct.clone(),
+        })
+        .await?;
+    let access_token = String::from_utf8(access_plain)
+        .map_err(|_| PatreonError::Crypto("access token not UTF-8 after decrypt".into()))?;
+
+    // Fast path: token still valid by our recorded expiry. Patreon may have
+    // revoked the token server-side anyway, in which case the membership
+    // call below returns 401 and we'd want to refresh — but we don't refresh
+    // pre-emptively here to keep this read path cheap. A future iteration
+    // can add the 401-triggered refresh + persist cycle.
+    let now = Utc::now().timestamp();
+    let _stale = now >= link.token_expires_at;
+    let _ = oauth; // refresh-on-401 path not yet implemented; see comment above.
+
+    let snap = match link.role.as_str() {
+        "creator" => {
+            // For creators, the snapshot is informational — the relevant
+            // membership data is the consumer's, not the creator's. Embed
+            // the campaign id so RPs can look up "which creator does this
+            // user own".
+            let memberships = Vec::new();
+            ArkavoPatreon {
+                role: "creator".into(),
+                patreon_user_id: link.patreon_user_id.clone(),
+                campaign_id: link.campaign_id.clone(),
+                memberships,
+                verified_at: now,
+                cache_expires_at: now + PATREON_CACHE_TTL_SECONDS,
+            }
+        }
+        _ => {
+            // Consumer: query Patreon for memberships.
+            let memberships = match fetch_consumer_memberships(&state.http, &access_token).await {
+                Ok(m) => m,
+                Err(e) => {
+                    warn!(
+                        "Patreon consumer membership fetch failed: {} — embedding empty list",
+                        e
+                    );
+                    Vec::new()
+                }
+            };
+            ArkavoPatreon {
+                role: "consumer".into(),
+                patreon_user_id: link.patreon_user_id.clone(),
+                campaign_id: None,
+                memberships,
+                verified_at: now,
+                cache_expires_at: now + PATREON_CACHE_TTL_SECONDS,
+            }
+        }
+    };
+    Ok(snap)
+}
+
+/// Pull the consumer's memberships from Patreon's `/identity` endpoint.
+///
+/// We request `include=memberships,memberships.currently_entitled_tiers,memberships.campaign`
+/// so a single round-trip returns campaign id + patron_status + tier ids.
+async fn fetch_consumer_memberships(
+    http: &reqwest::Client,
+    access_token: &str,
+) -> Result<Vec<ArkavoPatreonMembership>, PatreonError> {
+    let url = format!(
+        "{}?include=memberships,memberships.currently_entitled_tiers,memberships.campaign\
+        &fields%5Bmember%5D=patron_status",
+        PATREON_IDENTITY_URL
+    );
+    let resp = http
+        .get(&url)
+        .bearer_auth(access_token)
+        .send()
+        .await
+        .map_err(|e| PatreonError::Api(format!("identity GET: {}", e)))?;
+    if !resp.status().is_success() {
+        let status = resp.status();
+        let body = resp.text().await.unwrap_or_default();
+        return Err(PatreonError::Api(format!(
+            "identity endpoint returned {}: {}",
+            status,
+            truncate(&body, 256)
+        )));
+    }
+    let body: serde_json::Value = resp
+        .json()
+        .await
+        .map_err(|e| PatreonError::Api(format!("identity JSON parse: {}", e)))?;
+    Ok(parse_memberships_from_identity(&body))
+}
+
+/// Parse the Patreon JSON:API document into our membership shape.
+///
+/// JSON:API stores memberships in the `included` array (type=`member`), with
+/// each member's relationships pointing at its `campaign` and
+/// `currently_entitled_tiers`. We walk the `included` array twice: first to
+/// index tiers by id (no embedded attributes we need; tier presence is the
+/// signal), then to build the member rows.
+pub(crate) fn parse_memberships_from_identity(
+    body: &serde_json::Value,
+) -> Vec<ArkavoPatreonMembership> {
+    let Some(included) = body.get("included").and_then(|v| v.as_array()) else {
+        return Vec::new();
+    };
+
+    let mut out = Vec::new();
+    for entry in included {
+        if entry.get("type").and_then(|v| v.as_str()) != Some("member") {
+            continue;
+        }
+        let campaign_id = entry
+            .get("relationships")
+            .and_then(|r| r.get("campaign"))
+            .and_then(|c| c.get("data"))
+            .and_then(|d| d.get("id"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let Some(campaign_id) = campaign_id else {
+            continue;
+        };
+        let patron_status = entry
+            .get("attributes")
+            .and_then(|a| a.get("patron_status"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string());
+        let tier_ids: Vec<String> = entry
+            .get("relationships")
+            .and_then(|r| r.get("currently_entitled_tiers"))
+            .and_then(|t| t.get("data"))
+            .and_then(|d| d.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|t| t.get("id").and_then(|v| v.as_str()).map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default();
+        out.push(ArkavoPatreonMembership {
+            campaign_id,
+            patron_status,
+            tier_ids,
+        });
+    }
+    out
+}
+
+// --------- Helpers (copied from apple_signin to avoid cross-module coupling) ---------
+
+fn subject_prefix(sub: &str) -> &str {
+    match sub.char_indices().nth(8) {
+        Some((byte_idx, _)) => &sub[..byte_idx],
+        None => sub,
+    }
+}
+
+fn client_ip_from_headers(headers: &HeaderMap) -> String {
+    headers
+        .get("x-forwarded-for")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.split(',').next())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+fn extract_authenticated_user_id(
+    app_state: &AppState,
+    headers: &HeaderMap,
+) -> Result<Uuid, PatreonError> {
+    let token_header = headers
+        .get("X-Auth-Token")
+        .ok_or(PatreonError::MissingAuth)?;
+    let token_str = token_header
+        .to_str()
+        .map_err(|_| PatreonError::MissingAuth)?;
+    let claims = crate::authn::verify_inbound_account_token(app_state, token_str)
+        .map_err(|_| PatreonError::MissingAuth)?;
+    Uuid::parse_str(&claims.sub).map_err(|_| PatreonError::MissingAuth)
+}
+
+// Avoid a "PATREON_CAMPAIGN_MEMBERS_URL_TEMPLATE unused" warning: the
+// constant is exported for the future creator-side roster query path
+// (planned: webhook-driven cache warm-up), and tests reference it.
+#[allow(dead_code)]
+fn _campaign_members_url_used() -> &'static str {
+    PATREON_CAMPAIGN_MEMBERS_URL_TEMPLATE
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parse_memberships_extracts_active_patron_with_tiers() {
+        let body = json!({
+            "data": {"id": "user-1", "type": "user"},
+            "included": [
+                {
+                    "type": "member",
+                    "id": "m1",
+                    "attributes": {"patron_status": "active_patron"},
+                    "relationships": {
+                        "campaign": {"data": {"id": "camp-gold", "type": "campaign"}},
+                        "currently_entitled_tiers": {
+                            "data": [
+                                {"id": "tier-1", "type": "tier"},
+                                {"id": "tier-2", "type": "tier"}
+                            ]
+                        }
+                    }
+                }
+            ]
+        });
+        let parsed = parse_memberships_from_identity(&body);
+        assert_eq!(parsed.len(), 1);
+        assert_eq!(parsed[0].campaign_id, "camp-gold");
+        assert_eq!(parsed[0].patron_status.as_deref(), Some("active_patron"));
+        assert_eq!(parsed[0].tier_ids, vec!["tier-1", "tier-2"]);
+    }
+
+    #[test]
+    fn parse_memberships_ignores_non_member_includes() {
+        let body = json!({
+            "data": {"id": "user-1"},
+            "included": [
+                {"type": "campaign", "id": "camp-x"},
+                {"type": "tier", "id": "tier-x"},
+            ]
+        });
+        let parsed = parse_memberships_from_identity(&body);
+        assert!(parsed.is_empty());
+    }
+
+    #[test]
+    fn parse_memberships_skips_members_without_campaign_link() {
+        let body = json!({
+            "data": {"id": "user-1"},
+            "included": [
+                {
+                    "type": "member",
+                    "id": "m1",
+                    "attributes": {"patron_status": "active_patron"},
+                    "relationships": {
+                        "currently_entitled_tiers": {"data": []}
+                    }
+                }
+            ]
+        });
+        let parsed = parse_memberships_from_identity(&body);
+        assert!(
+            parsed.is_empty(),
+            "member without campaign should be skipped"
+        );
+    }
+
+    #[test]
+    fn parse_memberships_handles_no_included() {
+        let body = json!({"data": {"id": "user-1"}});
+        assert!(parse_memberships_from_identity(&body).is_empty());
+    }
+
+    #[test]
+    fn find_campaign_id_extracts_creator_campaign() {
+        let body = json!({
+            "data": {
+                "id": "user-1",
+                "relationships": {
+                    "campaign": {"data": {"id": "camp-z", "type": "campaign"}}
+                }
+            }
+        });
+        assert_eq!(find_campaign_id(&body).as_deref(), Some("camp-z"));
+    }
+
+    #[test]
+    fn find_campaign_id_returns_none_when_no_campaign() {
+        let body = json!({"data": {"id": "user-1"}});
+        assert!(find_campaign_id(&body).is_none());
+    }
+
+    #[test]
+    fn truncate_respects_char_boundaries() {
+        let s = "αβγδ"; // 4 chars, 8 bytes
+        assert_eq!(truncate(s, 100), s);
+        let truncated = truncate(s, 3);
+        // 3 bytes lands mid-codepoint; should back off to 2.
+        assert!(truncated.len() <= 3);
+        assert!(s.starts_with(&truncated));
+    }
+
+    #[test]
+    fn patreon_error_status_codes() {
+        assert_eq!(
+            PatreonError::NotConfigured.into_response().status(),
+            StatusCode::SERVICE_UNAVAILABLE
+        );
+        assert_eq!(
+            PatreonError::InvalidRedirectUri.into_response().status(),
+            StatusCode::BAD_REQUEST
+        );
+        assert_eq!(
+            PatreonError::InvalidRole.into_response().status(),
+            StatusCode::BAD_REQUEST
+        );
+        assert_eq!(
+            PatreonError::MissingAuth.into_response().status(),
+            StatusCode::UNAUTHORIZED
+        );
+        assert_eq!(
+            PatreonError::Api("x".into()).into_response().status(),
+            StatusCode::BAD_GATEWAY
+        );
+        assert_eq!(
+            PatreonError::LinkConflict.into_response().status(),
+            StatusCode::CONFLICT
+        );
+        assert_eq!(
+            PatreonError::Kms("x".into()).into_response().status(),
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
+    }
+
+    #[tokio::test]
+    async fn plaintext_sealer_roundtrips_long_token() {
+        let sealer = TokenSealer::Plaintext;
+        let plaintext = b"patreon-access-token-".repeat(100);
+        let sealed = sealer.seal(&plaintext).await.expect("seal");
+        assert_ne!(sealed.ciphertext, plaintext);
+        let opened = sealer.open(&sealed).await.expect("open");
+        assert_eq!(opened, plaintext);
+    }
+
+    #[tokio::test]
+    async fn plaintext_sealer_seal_under_existing_dek_distinct_nonces() {
+        let sealer = TokenSealer::Plaintext;
+        let access = sealer.seal(b"access-token").await.expect("seal access");
+        let refresh = seal_under_existing_dek(&sealer, &access.wrapped_dek, b"refresh-token")
+            .await
+            .expect("seal refresh");
+        assert_eq!(refresh.wrapped_dek, access.wrapped_dek);
+        assert_ne!(refresh.nonce, access.nonce, "nonces must differ");
+        let opened_access = sealer.open(&access).await.expect("open access");
+        let opened_refresh = sealer.open(&refresh).await.expect("open refresh");
+        assert_eq!(opened_access, b"access-token");
+        assert_eq!(opened_refresh, b"refresh-token");
+    }
+
+    #[tokio::test]
+    async fn plaintext_sealer_rejects_tampered_ciphertext() {
+        let sealer = TokenSealer::Plaintext;
+        let mut sealed = sealer.seal(b"hello").await.expect("seal");
+        sealed.ciphertext[0] ^= 0x01;
+        let result = sealer.open(&sealed).await;
+        assert!(matches!(result, Err(PatreonError::Crypto(_))));
+    }
+
+    #[tokio::test]
+    async fn membership_cache_in_memory_roundtrip() {
+        // Redis isn't connected in unit tests, so we exercise the in-memory
+        // fallback path. This is the same code that runs in production when
+        // the Redis connection drops mid-session.
+        let redis =
+            fred::clients::RedisClient::new(fred::types::RedisConfig::default(), None, None, None);
+        let cache = MembershipCache::new(redis);
+        let user_id = Uuid::new_v4();
+        let now = Utc::now().timestamp();
+        let snap = ArkavoPatreon {
+            role: "consumer".into(),
+            patreon_user_id: "p-1".into(),
+            campaign_id: None,
+            memberships: vec![ArkavoPatreonMembership {
+                campaign_id: "camp-1".into(),
+                patron_status: Some("active_patron".into()),
+                tier_ids: vec!["tier-1".into()],
+            }],
+            verified_at: now,
+            cache_expires_at: now + 300,
+        };
+        cache.put(user_id, &snap).await;
+        let got = cache.get(user_id).await.expect("cache hit");
+        assert_eq!(got, snap);
+        cache.invalidate(user_id).await;
+        assert!(cache.get(user_id).await.is_none(), "invalidate clears");
+    }
+
+    #[tokio::test]
+    async fn membership_cache_drops_expired_entries() {
+        let redis =
+            fred::clients::RedisClient::new(fred::types::RedisConfig::default(), None, None, None);
+        let cache = MembershipCache::new(redis);
+        let user_id = Uuid::new_v4();
+        let snap = ArkavoPatreon {
+            role: "consumer".into(),
+            patreon_user_id: "p-1".into(),
+            campaign_id: None,
+            memberships: vec![],
+            verified_at: 0,
+            cache_expires_at: 1, // already expired
+        };
+        cache.put(user_id, &snap).await;
+        // The retain-on-read sweep should drop the expired row.
+        assert!(cache.get(user_id).await.is_none());
+    }
+
+    #[test]
+    fn subject_prefix_caps_at_eight_chars() {
+        assert_eq!(subject_prefix("0123456789abc"), "01234567");
+        assert_eq!(subject_prefix("short"), "short");
+        assert_eq!(subject_prefix(""), "");
+    }
+
+    #[test]
+    fn link_request_deserializes_minimal_shape() {
+        let body = serde_json::json!({
+            "code": "abc123",
+            "redirect_uri": "https://identity.arkavo.net/oauth/patreon/cb",
+            "role": "consumer",
+        });
+        let req: LinkRequest = serde_json::from_value(body).expect("parse");
+        assert_eq!(req.code, "abc123");
+        assert_eq!(req.role, "consumer");
+    }
+
+    #[test]
+    fn patreon_oauth_config_requires_redirect_uris() {
+        // Force env to a clean state for the duration of this test.
+        unsafe {
+            std::env::set_var("PATREON_CLIENT_ID", "test-client");
+            std::env::set_var("PATREON_CLIENT_SECRET", "test-secret");
+            std::env::remove_var("PATREON_REDIRECT_URIS");
+        }
+        assert!(PatreonOAuthConfig::from_env().is_none());
+
+        unsafe {
+            std::env::set_var("PATREON_REDIRECT_URIS", "https://a/cb, https://b/cb");
+        }
+        let cfg = PatreonOAuthConfig::from_env().expect("config builds");
+        assert_eq!(cfg.client_id, "test-client");
+        assert_eq!(cfg.client_secret, "test-secret");
+        assert_eq!(
+            cfg.redirect_uris,
+            vec!["https://a/cb".to_string(), "https://b/cb".to_string()]
+        );
+
+        // Cleanup so other tests aren't affected.
+        unsafe {
+            std::env::remove_var("PATREON_CLIENT_ID");
+            std::env::remove_var("PATREON_CLIENT_SECRET");
+            std::env::remove_var("PATREON_REDIRECT_URIS");
+        }
+    }
+}

--- a/src/patreon.rs
+++ b/src/patreon.rs
@@ -319,6 +319,10 @@ pub enum PatreonError {
     InvalidRedirectUri,
     #[error("role must be \"creator\" or \"consumer\"")]
     InvalidRole,
+    #[error("role=creator but no Patreon campaign is owned by this account")]
+    NoCampaign,
+    #[error("Patreon rejected the authorization code (expired, replayed, or invalid)")]
+    InvalidGrant,
     #[error("missing or invalid X-Auth-Token")]
     MissingAuth,
     #[error("Patreon API error: {0}")]
@@ -340,7 +344,10 @@ impl IntoResponse for PatreonError {
     fn into_response(self) -> Response {
         let status = match &self {
             PatreonError::NotConfigured => StatusCode::SERVICE_UNAVAILABLE,
-            PatreonError::InvalidRedirectUri | PatreonError::InvalidRole => StatusCode::BAD_REQUEST,
+            PatreonError::InvalidRedirectUri
+            | PatreonError::InvalidRole
+            | PatreonError::NoCampaign
+            | PatreonError::InvalidGrant => StatusCode::BAD_REQUEST,
             PatreonError::MissingAuth => StatusCode::UNAUTHORIZED,
             PatreonError::Api(_) => StatusCode::BAD_GATEWAY,
             PatreonError::LinkConflict => StatusCode::CONFLICT,
@@ -349,7 +356,32 @@ impl IntoResponse for PatreonError {
             | PatreonError::Db(_)
             | PatreonError::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
         };
-        (status, self.to_string()).into_response()
+        // Only expose safe, pre-defined messages to clients. The `Api`, `Kms`,
+        // `Crypto`, and `Db` variants embed raw upstream diagnostics (KMS ARNs,
+        // DynamoDB internals, Patreon response bodies) — those stay in the
+        // server logs (already emitted via error!/warn! at the call sites) and
+        // must never reach the wire.
+        let body: &str = match &self {
+            PatreonError::NotConfigured => "Patreon integration is not configured",
+            PatreonError::InvalidRedirectUri => "redirect_uri is not in the allow list",
+            PatreonError::InvalidRole => "role must be \"creator\" or \"consumer\"",
+            PatreonError::NoCampaign => {
+                "role=creator but no Patreon campaign is owned by this account"
+            }
+            PatreonError::InvalidGrant => {
+                "Patreon rejected the authorization code (expired, replayed, or invalid)"
+            }
+            PatreonError::MissingAuth => "missing or invalid X-Auth-Token",
+            PatreonError::LinkConflict => {
+                "Patreon identity already linked to a different arkavo user"
+            }
+            PatreonError::Api(_) => "upstream Patreon request failed",
+            PatreonError::Kms(_) | PatreonError::Crypto(_) | PatreonError::Db(_) => {
+                "internal error"
+            }
+            PatreonError::Internal(_) => "internal error",
+        };
+        (status, body.to_string()).into_response()
     }
 }
 
@@ -464,6 +496,16 @@ pub async fn patreon_link_handler(
             return e.into_response();
         }
     };
+
+    // role is client-asserted; refuse to persist a creator link with no owned
+    // campaign (it would materialize empty entitlements forever).
+    if let Err(e) = validate_creator_campaign(&role, &campaign_id) {
+        warn!(
+            "Patreon link rejected: role=creator but no campaign for subject_prefix={}",
+            subject_prefix(&patreon_user_id)
+        );
+        return e.into_response();
+    }
 
     // 3. Persist the link. identity_links first (uniqueness check), then
     //    patreon_tokens. Order matters: identity_links is the per-Patreon-
@@ -604,6 +646,22 @@ struct PatreonTokenResponse {
     pub token_type: String,
 }
 
+/// Classify a non-success Patreon token-endpoint response. Client errors (4xx)
+/// mean the *caller's* `code`/`redirect_uri` was bad → surface a 400. Server
+/// errors / unexpected statuses are Patreon's fault → 502 with diagnostics for
+/// the logs only.
+fn token_exchange_error(status: reqwest::StatusCode, body: &str) -> PatreonError {
+    if status.is_client_error() {
+        PatreonError::InvalidGrant
+    } else {
+        PatreonError::Api(format!(
+            "token endpoint returned {}: {}",
+            status,
+            truncate(body, 256)
+        ))
+    }
+}
+
 async fn exchange_code_for_tokens(
     http: &reqwest::Client,
     oauth: &PatreonOAuthConfig,
@@ -626,22 +684,20 @@ async fn exchange_code_for_tokens(
     if !resp.status().is_success() {
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
-        return Err(PatreonError::Api(format!(
-            "token endpoint returned {}: {}",
-            status,
-            truncate(&body, 256)
-        )));
+        return Err(token_exchange_error(status, &body));
     }
     resp.json::<PatreonTokenResponse>()
         .await
         .map_err(|e| PatreonError::Api(format!("token JSON parse: {}", e)))
 }
 
-/// Refresh a Patreon access token using its refresh token. Wired through to
-/// `materialize_from_link` in a follow-up change so a stale access token
-/// triggers refresh-and-persist on the access_token mint path; today the
-/// mint path just serves an empty membership snapshot when Patreon returns
-/// 401. The helper itself is correct, the integration is the deferred piece.
+/// Refresh a Patreon access token using its refresh token. To be wired into
+/// `materialize_from_link` in a follow-up so a stale/revoked access token
+/// triggers refresh-and-persist on the access_token mint path. Until then the
+/// mint path fails closed: a 401 (or any fetch error) propagates and the
+/// `arkavo_patreon` claim is omitted entirely — so an expired access token
+/// silently drops the user's entitlements until they re-link. The helper
+/// itself is correct; only the 401-triggered integration is deferred.
 #[allow(dead_code)]
 async fn refresh_access_token(
     http: &reqwest::Client,
@@ -674,6 +730,17 @@ async fn refresh_access_token(
         .map_err(|e| PatreonError::Api(format!("refresh JSON parse: {}", e)))
 }
 
+/// Build the `/identity` URL. Creators add the `campaign` relationship so we
+/// can discover the owned campaign id; consumers need none of it. We never
+/// request the `email` field — minimum-PII, and it's never read.
+fn identity_url(is_creator: bool) -> String {
+    if is_creator {
+        format!("{}?include=campaign", PATREON_IDENTITY_URL)
+    } else {
+        PATREON_IDENTITY_URL.to_string()
+    }
+}
+
 /// Fetch the current user's Patreon identity, returning
 /// `(patreon_user_id, Option<campaign_id>)`. Campaign discovery only runs
 /// for creators (and only the first campaign is captured — multi-campaign
@@ -683,12 +750,7 @@ async fn fetch_identity(
     access_token: &str,
     is_creator: bool,
 ) -> Result<(String, Option<String>), PatreonError> {
-    let mut url = String::from(PATREON_IDENTITY_URL);
-    if is_creator {
-        // The `campaign` relationship is creator-only — for consumers it's
-        // empty and the extra include is harmless but wasteful.
-        url.push_str("?include=campaign&fields%5Buser%5D=email");
-    }
+    let url = identity_url(is_creator);
     let resp = http
         .get(&url)
         .bearer_auth(access_token)
@@ -740,6 +802,16 @@ fn find_campaign_id(body: &serde_json::Value) -> Option<String> {
         .map(|s| s.to_string())
 }
 
+/// Guard against persisting a contradictory creator link. `role` is asserted
+/// by the client; if it claims `creator` but Patreon reports no owned campaign,
+/// the row would materialize empty entitlements forever — reject up front.
+fn validate_creator_campaign(role: &str, campaign_id: &Option<String>) -> Result<(), PatreonError> {
+    if role == "creator" && campaign_id.is_none() {
+        return Err(PatreonError::NoCampaign);
+    }
+    Ok(())
+}
+
 fn truncate(s: &str, max: usize) -> String {
     if s.len() <= max {
         return s.to_string();
@@ -752,6 +824,12 @@ fn truncate(s: &str, max: usize) -> String {
 }
 
 // --------- Membership materialization (used by OIDC access_token mint) ---------
+
+/// Hard cap on the in-memory fallback map (used only while Redis is down).
+/// Bounds memory if Redis stays unreachable under sustained load; once the cap
+/// is hit, new users simply re-materialize on each mint instead of being
+/// cached. Redis remains the unbounded-by-TTL primary store.
+const MAX_LOCAL_CACHE_ENTRIES: usize = 10_000;
 
 #[derive(Clone)]
 pub struct MembershipCache {
@@ -815,7 +893,14 @@ impl MembershipCache {
             }
         } else {
             let mut map = self.local.lock().unwrap();
-            map.insert(key, (snap.clone(), snap.cache_expires_at));
+            // Reclaim expired entries first, then enforce the cap. We still
+            // refresh an existing key even at capacity (it's not net growth);
+            // only brand-new keys are dropped once full.
+            let now = Utc::now().timestamp();
+            map.retain(|_, (_, exp)| *exp > now);
+            if map.len() < MAX_LOCAL_CACHE_ENTRIES || map.contains_key(&key) {
+                map.insert(key, (snap.clone(), snap.cache_expires_at));
+            }
         }
     }
 
@@ -977,17 +1062,14 @@ async fn materialize_from_link(
             }
         }
         _ => {
-            // Consumer: query Patreon for memberships.
-            let memberships = match fetch_consumer_memberships(&state.http, &access_token).await {
-                Ok(m) => m,
-                Err(e) => {
-                    warn!(
-                        "Patreon consumer membership fetch failed: {} — embedding empty list",
-                        e
-                    );
-                    Vec::new()
-                }
-            };
+            // Consumer: query Patreon for memberships. A fetch *failure* must
+            // propagate — the caller (materialize_for_user) fails closed by
+            // omitting the claim entirely and NOT caching. Swallowing the error
+            // into an empty list would cache a false "no entitlement" for the
+            // full TTL on any transient Patreon blip or token expiry. A genuine
+            // HTTP 200 with no memberships still yields Ok(vec![]) here and is
+            // cached as a real (empty) snapshot.
+            let memberships = fetch_consumer_memberships(&state.http, &access_token).await?;
             ArkavoPatreon {
                 role: "consumer".into(),
                 patreon_user_id: link.patreon_user_id.clone(),
@@ -1226,6 +1308,39 @@ mod tests {
     }
 
     #[test]
+    fn identity_url_creator_includes_campaign_but_not_email() {
+        // Minimum-PII: we only need data.id + campaign relationship; never
+        // request the user's email from Patreon.
+        let url = identity_url(true);
+        assert!(url.contains("include=campaign"), "creator url: {url}");
+        assert!(
+            !url.to_lowercase().contains("email"),
+            "creator url must not request email: {url}"
+        );
+    }
+
+    #[test]
+    fn identity_url_consumer_has_no_query() {
+        assert_eq!(identity_url(false), PATREON_IDENTITY_URL);
+    }
+
+    #[test]
+    fn token_exchange_client_error_maps_to_invalid_grant() {
+        // A bad/expired/replayed auth code is the *client's* fault — surface a
+        // 400, not a 502 that implies Patreon is down.
+        let err = token_exchange_error(reqwest::StatusCode::BAD_REQUEST, "invalid_grant");
+        assert!(matches!(err, PatreonError::InvalidGrant));
+        assert_eq!(err.into_response().status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn token_exchange_server_error_maps_to_bad_gateway() {
+        let err = token_exchange_error(reqwest::StatusCode::INTERNAL_SERVER_ERROR, "boom");
+        assert!(matches!(err, PatreonError::Api(_)));
+        assert_eq!(err.into_response().status(), StatusCode::BAD_GATEWAY);
+    }
+
+    #[test]
     fn truncate_respects_char_boundaries() {
         let s = "αβγδ"; // 4 chars, 8 bytes
         assert_eq!(truncate(s, 100), s);
@@ -1265,6 +1380,40 @@ mod tests {
             PatreonError::Kms("x".into()).into_response().status(),
             StatusCode::INTERNAL_SERVER_ERROR
         );
+    }
+
+    #[tokio::test]
+    async fn into_response_redacts_server_side_error_details() {
+        use axum::body::to_bytes;
+        // Server-side (5xx) variants must never echo raw upstream diagnostics
+        // (KMS ARNs, DynamoDB internals, Patreon bodies) to the client.
+        let cases = [
+            PatreonError::Kms("arn:aws:kms:us-east-1:123456789012:key/SECRET-KMS-DETAIL".into()),
+            PatreonError::Crypto("SECRET-KMS-DETAIL nonce internals".into()),
+            PatreonError::Db("SECRET-KMS-DETAIL table scan".into()),
+            PatreonError::Internal("SECRET-KMS-DETAIL stack".into()),
+        ];
+        for err in cases {
+            let resp = err.into_response();
+            assert_eq!(resp.status(), StatusCode::INTERNAL_SERVER_ERROR);
+            let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+            let text = String::from_utf8_lossy(&bytes);
+            assert!(
+                !text.contains("SECRET-KMS-DETAIL"),
+                "5xx body leaked internal detail: {text}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn into_response_keeps_safe_client_facing_messages() {
+        use axum::body::to_bytes;
+        // 4xx variants carry no sensitive data and may keep their descriptive
+        // body so the caller can correct the request.
+        let resp = PatreonError::InvalidRole.into_response();
+        let bytes = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let text = String::from_utf8_lossy(&bytes);
+        assert!(text.contains("creator"), "client-facing 4xx body: {text}");
     }
 
     #[tokio::test]
@@ -1330,6 +1479,94 @@ mod tests {
         assert!(cache.get(user_id).await.is_none(), "invalidate clears");
     }
 
+    /// reqwest client whose DNS for the Patreon host resolves to a dead local
+    /// port, so any outbound Patreon call fails fast and offline.
+    fn unreachable_patreon_http() -> reqwest::Client {
+        reqwest::Client::builder()
+            .resolve(
+                "www.patreon.com",
+                "127.0.0.1:1".parse::<std::net::SocketAddr>().unwrap(),
+            )
+            .timeout(std::time::Duration::from_secs(2))
+            .build()
+            .unwrap()
+    }
+
+    async fn consumer_link_with_token(sealer: &TokenSealer, token: &[u8]) -> PatreonLink {
+        let access = sealer.seal(token).await.expect("seal access");
+        let refresh = seal_under_existing_dek(sealer, &access.wrapped_dek, b"refresh")
+            .await
+            .expect("seal refresh");
+        let now = Utc::now().timestamp();
+        PatreonLink {
+            user_id: Uuid::new_v4(),
+            role: "consumer".into(),
+            patreon_user_id: "p-1".into(),
+            campaign_id: None,
+            scopes: String::new(),
+            access_token_ct: access.ciphertext,
+            access_token_nonce: access.nonce,
+            refresh_token_ct: refresh.ciphertext,
+            refresh_token_nonce: refresh.nonce,
+            wrapped_dek: access.wrapped_dek,
+            token_expires_at: now + 3600,
+            linked_at: now,
+        }
+    }
+
+    #[tokio::test]
+    async fn consumer_fetch_failure_propagates_does_not_yield_empty_snapshot() {
+        // Fail-closed contract: when Patreon is unreachable, materialization
+        // must return Err (so materialize_for_user omits the claim and does NOT
+        // cache), NOT Ok with an empty membership list that would be cached for
+        // the full TTL and read downstream as "no entitlement".
+        let sealer = TokenSealer::Plaintext;
+        let link = consumer_link_with_token(&sealer, b"access-token").await;
+        let redis =
+            fred::clients::RedisClient::new(fred::types::RedisConfig::default(), None, None, None);
+        let state = PatreonState {
+            oauth: Some(PatreonOAuthConfig {
+                client_id: "c".into(),
+                client_secret: "s".into(),
+                redirect_uris: vec!["https://x/cb".into()],
+            }),
+            sealer: Some(sealer),
+            http: unreachable_patreon_http(),
+            cache: MembershipCache::new(redis),
+        };
+        let result = materialize_from_link(&state, &link).await;
+        assert!(
+            result.is_err(),
+            "unreachable Patreon must propagate an error, got: {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn in_memory_cache_fallback_is_bounded() {
+        // Redis disconnected → local fallback. Inserting more distinct,
+        // non-expired users than the cap must not grow the map past the cap.
+        let redis =
+            fred::clients::RedisClient::new(fred::types::RedisConfig::default(), None, None, None);
+        let cache = MembershipCache::new(redis);
+        let now = Utc::now().timestamp();
+        let snap = ArkavoPatreon {
+            role: "consumer".into(),
+            patreon_user_id: "p".into(),
+            campaign_id: None,
+            memberships: vec![],
+            verified_at: now,
+            cache_expires_at: now + 3600, // not expired, so retain can't reclaim
+        };
+        for _ in 0..(MAX_LOCAL_CACHE_ENTRIES + 25) {
+            cache.put(Uuid::new_v4(), &snap).await;
+        }
+        let len = cache.local.lock().unwrap().len();
+        assert!(
+            len <= MAX_LOCAL_CACHE_ENTRIES,
+            "local cache grew to {len}, exceeding cap {MAX_LOCAL_CACHE_ENTRIES}"
+        );
+    }
+
     #[tokio::test]
     async fn membership_cache_drops_expired_entries() {
         let redis =
@@ -1354,6 +1591,29 @@ mod tests {
         assert_eq!(subject_prefix("0123456789abc"), "01234567");
         assert_eq!(subject_prefix("short"), "short");
         assert_eq!(subject_prefix(""), "");
+    }
+
+    #[test]
+    fn creator_without_campaign_is_rejected() {
+        // A creator link with no discoverable campaign would persist a
+        // contradictory row (role=creator, campaign_id=None) that materializes
+        // empty entitlements forever. Reject it at link time instead.
+        assert!(matches!(
+            validate_creator_campaign("creator", &None),
+            Err(PatreonError::NoCampaign)
+        ));
+        // Creator with a campaign is fine.
+        assert!(validate_creator_campaign("creator", &Some("camp-1".into())).is_ok());
+        // Consumers never require a campaign.
+        assert!(validate_creator_campaign("consumer", &None).is_ok());
+    }
+
+    #[test]
+    fn no_campaign_error_maps_to_400() {
+        assert_eq!(
+            PatreonError::NoCampaign.into_response().status(),
+            StatusCode::BAD_REQUEST
+        );
     }
 
     #[test]

--- a/src/patreon.rs
+++ b/src/patreon.rs
@@ -286,6 +286,11 @@ pub struct PatreonState {
     pub sealer: Option<TokenSealer>,
     pub http: reqwest::Client,
     pub cache: MembershipCache,
+    /// Patreon OAuth2 token endpoint. Defaults to the production constant;
+    /// overridable so tests (and staging) can point at a local/sandbox server.
+    pub token_url: String,
+    /// Patreon API v2 identity endpoint (base, without query). See `token_url`.
+    pub identity_url: String,
 }
 
 impl PatreonState {
@@ -303,6 +308,8 @@ impl PatreonState {
                 .build()
                 .unwrap_or_else(|_| reqwest::Client::new()),
             cache: MembershipCache::new(redis),
+            token_url: PATREON_TOKEN_URL.to_string(),
+            identity_url: PATREON_IDENTITY_URL.to_string(),
         }
     }
 
@@ -327,6 +334,8 @@ pub enum PatreonError {
     MissingAuth,
     #[error("Patreon API error: {0}")]
     Api(String),
+    #[error("Patreon rejected the access token (expired or revoked)")]
+    Unauthorized,
     #[error("KMS error: {0}")]
     Kms(String),
     #[error("Crypto error: {0}")]
@@ -349,7 +358,11 @@ impl IntoResponse for PatreonError {
             | PatreonError::NoCampaign
             | PatreonError::InvalidGrant => StatusCode::BAD_REQUEST,
             PatreonError::MissingAuth => StatusCode::UNAUTHORIZED,
-            PatreonError::Api(_) => StatusCode::BAD_GATEWAY,
+            // A Patreon-side 401 is an upstream/token problem, not a problem
+            // with the *caller's* request to us → surface as BAD_GATEWAY. In
+            // the materialization path this is caught and triggers a refresh
+            // before it can become a response.
+            PatreonError::Api(_) | PatreonError::Unauthorized => StatusCode::BAD_GATEWAY,
             PatreonError::LinkConflict => StatusCode::CONFLICT,
             PatreonError::Kms(_)
             | PatreonError::Crypto(_)
@@ -376,6 +389,7 @@ impl IntoResponse for PatreonError {
                 "Patreon identity already linked to a different arkavo user"
             }
             PatreonError::Api(_) => "upstream Patreon request failed",
+            PatreonError::Unauthorized => "Patreon rejected the access token",
             PatreonError::Kms(_) | PatreonError::Crypto(_) | PatreonError::Db(_) => {
                 "internal error"
             }
@@ -473,20 +487,28 @@ pub async fn patreon_link_handler(
     }
 
     // 1. Exchange the code for tokens.
-    let tokens =
-        match exchange_code_for_tokens(&state.http, oauth, &req.code, &req.redirect_uri).await {
-            Ok(t) => t,
-            Err(e) => {
-                warn!("Patreon code exchange failed: {}", e);
-                return e.into_response();
-            }
-        };
+    let tokens = match exchange_code_for_tokens(
+        &state.http,
+        oauth,
+        &req.code,
+        &req.redirect_uri,
+        &state.token_url,
+    )
+    .await
+    {
+        Ok(t) => t,
+        Err(e) => {
+            warn!("Patreon code exchange failed: {}", e);
+            return e.into_response();
+        }
+    };
 
     // 2. Discover patreon_user_id (+ campaign_id for creators).
     let (patreon_user_id, campaign_id) = match fetch_identity(
         &state.http,
         &tokens.access_token,
         role.as_str() == "creator",
+        &state.identity_url,
     )
     .await
     {
@@ -662,11 +684,55 @@ fn token_exchange_error(status: reqwest::StatusCode, body: &str) -> PatreonError
     }
 }
 
+/// Build the updated [`PatreonLink`] after a successful token refresh. Keeps
+/// the immutable identity fields (user, Patreon user/campaign, role,
+/// `linked_at`) and swaps in the freshly-sealed access/refresh ciphertexts,
+/// new scopes, and recomputed expiry. Patreon rotates the refresh token on
+/// every refresh, so both ciphertexts are replaced.
+fn merge_refreshed_link(
+    old: &PatreonLink,
+    new_tokens: &PatreonTokenResponse,
+    sealed_access: SealedToken,
+    sealed_refresh: SealedToken,
+    now: i64,
+) -> PatreonLink {
+    PatreonLink {
+        user_id: old.user_id,
+        role: old.role.clone(),
+        patreon_user_id: old.patreon_user_id.clone(),
+        campaign_id: old.campaign_id.clone(),
+        scopes: new_tokens.scope.clone(),
+        access_token_ct: sealed_access.ciphertext,
+        access_token_nonce: sealed_access.nonce,
+        refresh_token_ct: sealed_refresh.ciphertext,
+        refresh_token_nonce: sealed_refresh.nonce,
+        wrapped_dek: sealed_access.wrapped_dek,
+        token_expires_at: now + new_tokens.expires_in,
+        linked_at: old.linked_at,
+    }
+}
+
+/// Classify a non-success Patreon `/identity` (or membership) response. A 401
+/// means our stored access token is stale/revoked and the caller may refresh;
+/// everything else is an opaque upstream failure.
+fn identity_fetch_error(status: reqwest::StatusCode, body: &str) -> PatreonError {
+    if status == reqwest::StatusCode::UNAUTHORIZED {
+        PatreonError::Unauthorized
+    } else {
+        PatreonError::Api(format!(
+            "identity endpoint returned {}: {}",
+            status,
+            truncate(body, 256)
+        ))
+    }
+}
+
 async fn exchange_code_for_tokens(
     http: &reqwest::Client,
     oauth: &PatreonOAuthConfig,
     code: &str,
     redirect_uri: &str,
+    token_url: &str,
 ) -> Result<PatreonTokenResponse, PatreonError> {
     let form = [
         ("code", code),
@@ -676,7 +742,7 @@ async fn exchange_code_for_tokens(
         ("redirect_uri", redirect_uri),
     ];
     let resp = http
-        .post(PATREON_TOKEN_URL)
+        .post(token_url)
         .form(&form)
         .send()
         .await
@@ -691,18 +757,14 @@ async fn exchange_code_for_tokens(
         .map_err(|e| PatreonError::Api(format!("token JSON parse: {}", e)))
 }
 
-/// Refresh a Patreon access token using its refresh token. To be wired into
-/// `materialize_from_link` in a follow-up so a stale/revoked access token
-/// triggers refresh-and-persist on the access_token mint path. Until then the
-/// mint path fails closed: a 401 (or any fetch error) propagates and the
-/// `arkavo_patreon` claim is omitted entirely — so an expired access token
-/// silently drops the user's entitlements until they re-link. The helper
-/// itself is correct; only the 401-triggered integration is deferred.
-#[allow(dead_code)]
+/// Refresh a Patreon access token using its refresh token. Wired into
+/// `materialize_from_link`: a consumer membership fetch that returns 401
+/// triggers refresh-and-retry, and the caller persists the rotated tokens.
 async fn refresh_access_token(
     http: &reqwest::Client,
     oauth: &PatreonOAuthConfig,
     refresh_token: &str,
+    token_url: &str,
 ) -> Result<PatreonTokenResponse, PatreonError> {
     let form = [
         ("grant_type", "refresh_token"),
@@ -711,7 +773,7 @@ async fn refresh_access_token(
         ("client_secret", oauth.client_secret.as_str()),
     ];
     let resp = http
-        .post(PATREON_TOKEN_URL)
+        .post(token_url)
         .form(&form)
         .send()
         .await
@@ -730,14 +792,14 @@ async fn refresh_access_token(
         .map_err(|e| PatreonError::Api(format!("refresh JSON parse: {}", e)))
 }
 
-/// Build the `/identity` URL. Creators add the `campaign` relationship so we
-/// can discover the owned campaign id; consumers need none of it. We never
-/// request the `email` field — minimum-PII, and it's never read.
-fn identity_url(is_creator: bool) -> String {
+/// Build the `/identity` URL from a base. Creators add the `campaign`
+/// relationship so we can discover the owned campaign id; consumers need none
+/// of it. We never request the `email` field — minimum-PII, never read.
+fn build_identity_url(base: &str, is_creator: bool) -> String {
     if is_creator {
-        format!("{}?include=campaign", PATREON_IDENTITY_URL)
+        format!("{}?include=campaign", base)
     } else {
-        PATREON_IDENTITY_URL.to_string()
+        base.to_string()
     }
 }
 
@@ -749,8 +811,9 @@ async fn fetch_identity(
     http: &reqwest::Client,
     access_token: &str,
     is_creator: bool,
+    identity_url: &str,
 ) -> Result<(String, Option<String>), PatreonError> {
-    let url = identity_url(is_creator);
+    let url = build_identity_url(identity_url, is_creator);
     let resp = http
         .get(&url)
         .bearer_auth(access_token)
@@ -760,11 +823,7 @@ async fn fetch_identity(
     if !resp.status().is_success() {
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
-        return Err(PatreonError::Api(format!(
-            "identity endpoint returned {}: {}",
-            status,
-            truncate(&body, 256)
-        )));
+        return Err(identity_fetch_error(status, &body));
     }
     let body: serde_json::Value = resp
         .json()
@@ -1005,8 +1064,8 @@ pub async fn materialize_for_user(
         }
     };
 
-    let snap = match materialize_from_link(state, &link).await {
-        Ok(snap) => snap,
+    let (snap, refreshed) = match materialize_from_link(state, &link).await {
+        Ok(v) => v,
         Err(e) => {
             warn!(
                 "Patreon materialization failed for user {}: {} — failing closed (no claim)",
@@ -1015,16 +1074,33 @@ pub async fn materialize_for_user(
             return None;
         }
     };
+
+    // If the access token was refreshed during materialization, persist the
+    // rotated tokens. Best-effort: a persist failure doesn't fail the mint (we
+    // already have the memberships) — the next mint simply refreshes again.
+    if let Some(new_link) = refreshed {
+        match app_state.db_store.put_patreon_link(&new_link).await {
+            Ok(()) => debug!("Persisted refreshed Patreon tokens for user {}", user_id),
+            Err(e) => warn!(
+                "Failed to persist refreshed Patreon tokens for user {}: {} — will refresh again next mint",
+                user_id, e
+            ),
+        }
+    }
+
     state.cache.put(user_id, &snap).await;
     Some(snap)
 }
 
+/// Produce the membership snapshot for a link. The returned `Option<PatreonLink>`
+/// is `Some` iff a token refresh happened and the caller should persist the
+/// rotated tokens. Any unrecoverable failure propagates — the caller fails
+/// closed (omits the claim, doesn't cache).
 async fn materialize_from_link(
     state: &PatreonState,
     link: &PatreonLink,
-) -> Result<ArkavoPatreon, PatreonError> {
+) -> Result<(ArkavoPatreon, Option<PatreonLink>), PatreonError> {
     let sealer = state.sealer.as_ref().ok_or(PatreonError::NotConfigured)?;
-    let oauth = state.oauth.as_ref().ok_or(PatreonError::NotConfigured)?;
 
     let access_plain = sealer
         .open(&SealedToken {
@@ -1036,51 +1112,109 @@ async fn materialize_from_link(
     let access_token = String::from_utf8(access_plain)
         .map_err(|_| PatreonError::Crypto("access token not UTF-8 after decrypt".into()))?;
 
-    // Fast path: token still valid by our recorded expiry. Patreon may have
-    // revoked the token server-side anyway, in which case the membership
-    // call below returns 401 and we'd want to refresh — but we don't refresh
-    // pre-emptively here to keep this read path cheap. A future iteration
-    // can add the 401-triggered refresh + persist cycle.
     let now = Utc::now().timestamp();
-    let _stale = now >= link.token_expires_at;
-    let _ = oauth; // refresh-on-401 path not yet implemented; see comment above.
 
-    let snap = match link.role.as_str() {
+    match link.role.as_str() {
         "creator" => {
             // For creators, the snapshot is informational — the relevant
-            // membership data is the consumer's, not the creator's. Embed
-            // the campaign id so RPs can look up "which creator does this
-            // user own".
-            let memberships = Vec::new();
-            ArkavoPatreon {
+            // membership data is the consumer's, not the creator's. Embed the
+            // campaign id so RPs can look up "which creator does this user own".
+            // No Patreon call is made, so no refresh is possible or needed.
+            let snap = ArkavoPatreon {
                 role: "creator".into(),
                 patreon_user_id: link.patreon_user_id.clone(),
                 campaign_id: link.campaign_id.clone(),
-                memberships,
+                memberships: Vec::new(),
                 verified_at: now,
                 cache_expires_at: now + PATREON_CACHE_TTL_SECONDS,
-            }
+            };
+            Ok((snap, None))
         }
         _ => {
-            // Consumer: query Patreon for memberships. A fetch *failure* must
-            // propagate — the caller (materialize_for_user) fails closed by
-            // omitting the claim entirely and NOT caching. Swallowing the error
-            // into an empty list would cache a false "no entitlement" for the
-            // full TTL on any transient Patreon blip or token expiry. A genuine
-            // HTTP 200 with no memberships still yields Ok(vec![]) here and is
-            // cached as a real (empty) snapshot.
-            let memberships = fetch_consumer_memberships(&state.http, &access_token).await?;
-            ArkavoPatreon {
+            // Consumer: query Patreon for memberships, refreshing the access
+            // token once on a 401. A genuine HTTP 200 with no memberships
+            // yields an empty list (cached as a real snapshot); any
+            // unrecoverable failure propagates so the caller fails closed.
+            let (memberships, refreshed) =
+                fetch_memberships_with_refresh(state, link, &access_token).await?;
+            let snap = ArkavoPatreon {
                 role: "consumer".into(),
                 patreon_user_id: link.patreon_user_id.clone(),
                 campaign_id: None,
                 memberships,
                 verified_at: now,
                 cache_expires_at: now + PATREON_CACHE_TTL_SECONDS,
-            }
+            };
+            Ok((snap, refreshed))
         }
-    };
-    Ok(snap)
+    }
+}
+
+/// Fetch consumer memberships, transparently refreshing the access token once
+/// if Patreon returns 401 (token expired/revoked). On refresh, returns the
+/// rotated [`PatreonLink`] so the caller can persist it; the retry fetch is
+/// authoritative (a second 401 propagates rather than looping).
+///
+/// Concurrency note: two simultaneous mints for the same user can both refresh.
+/// Patreon rotates the refresh token on use, so the slower refresh may fail (it
+/// reused an already-consumed refresh token) — that mint just fails closed for
+/// that request, and persistence is last-writer-wins. Acceptable for the read
+/// path; fully serializing refreshes (distributed lock / conditional update) is
+/// intentionally out of scope here.
+async fn fetch_memberships_with_refresh(
+    state: &PatreonState,
+    link: &PatreonLink,
+    access_token: &str,
+) -> Result<(Vec<ArkavoPatreonMembership>, Option<PatreonLink>), PatreonError> {
+    match fetch_consumer_memberships(&state.http, access_token, &state.identity_url).await {
+        Ok(m) => Ok((m, None)),
+        Err(PatreonError::Unauthorized) => {
+            let sealer = state.sealer.as_ref().ok_or(PatreonError::NotConfigured)?;
+            let oauth = state.oauth.as_ref().ok_or(PatreonError::NotConfigured)?;
+            info!(
+                "Patreon access token rejected (401) for patreon_user_id_prefix={}; refreshing",
+                subject_prefix(&link.patreon_user_id)
+            );
+
+            let refresh_plain = sealer
+                .open(&SealedToken {
+                    wrapped_dek: link.wrapped_dek.clone(),
+                    nonce: link.refresh_token_nonce.clone(),
+                    ciphertext: link.refresh_token_ct.clone(),
+                })
+                .await?;
+            let refresh_token = String::from_utf8(refresh_plain).map_err(|_| {
+                PatreonError::Crypto("refresh token not UTF-8 after decrypt".into())
+            })?;
+
+            let new_tokens =
+                refresh_access_token(&state.http, oauth, &refresh_token, &state.token_url).await?;
+
+            // Re-seal both rotated tokens under a fresh per-row DEK (distinct
+            // GCM nonces; one wrapped DEK per row).
+            let sealed_access = sealer.seal(new_tokens.access_token.as_bytes()).await?;
+            let sealed_refresh = seal_under_existing_dek(
+                sealer,
+                &sealed_access.wrapped_dek,
+                new_tokens.refresh_token.as_bytes(),
+            )
+            .await?;
+            let now = Utc::now().timestamp();
+            let refreshed_link =
+                merge_refreshed_link(link, &new_tokens, sealed_access, sealed_refresh, now);
+
+            // Retry once with the new access token. A failure here propagates
+            // (fail-closed) rather than triggering a second refresh.
+            let memberships = fetch_consumer_memberships(
+                &state.http,
+                &new_tokens.access_token,
+                &state.identity_url,
+            )
+            .await?;
+            Ok((memberships, Some(refreshed_link)))
+        }
+        Err(e) => Err(e),
+    }
 }
 
 /// Pull the consumer's memberships from Patreon's `/identity` endpoint.
@@ -1090,11 +1224,12 @@ async fn materialize_from_link(
 async fn fetch_consumer_memberships(
     http: &reqwest::Client,
     access_token: &str,
+    identity_url: &str,
 ) -> Result<Vec<ArkavoPatreonMembership>, PatreonError> {
     let url = format!(
         "{}?include=memberships,memberships.currently_entitled_tiers,memberships.campaign\
         &fields%5Bmember%5D=patron_status",
-        PATREON_IDENTITY_URL
+        identity_url
     );
     let resp = http
         .get(&url)
@@ -1105,11 +1240,7 @@ async fn fetch_consumer_memberships(
     if !resp.status().is_success() {
         let status = resp.status();
         let body = resp.text().await.unwrap_or_default();
-        return Err(PatreonError::Api(format!(
-            "identity endpoint returned {}: {}",
-            status,
-            truncate(&body, 256)
-        )));
+        return Err(identity_fetch_error(status, &body));
     }
     let body: serde_json::Value = resp
         .json()
@@ -1311,7 +1442,7 @@ mod tests {
     fn identity_url_creator_includes_campaign_but_not_email() {
         // Minimum-PII: we only need data.id + campaign relationship; never
         // request the user's email from Patreon.
-        let url = identity_url(true);
+        let url = build_identity_url(PATREON_IDENTITY_URL, true);
         assert!(url.contains("include=campaign"), "creator url: {url}");
         assert!(
             !url.to_lowercase().contains("email"),
@@ -1321,7 +1452,24 @@ mod tests {
 
     #[test]
     fn identity_url_consumer_has_no_query() {
-        assert_eq!(identity_url(false), PATREON_IDENTITY_URL);
+        assert_eq!(
+            build_identity_url(PATREON_IDENTITY_URL, false),
+            PATREON_IDENTITY_URL
+        );
+    }
+
+    #[test]
+    fn identity_fetch_401_classifies_as_unauthorized() {
+        // A 401 on a membership/identity fetch means our access token is
+        // stale/revoked → caller can trigger a refresh. Other failures stay Api.
+        assert!(matches!(
+            identity_fetch_error(reqwest::StatusCode::UNAUTHORIZED, "expired"),
+            PatreonError::Unauthorized
+        ));
+        assert!(matches!(
+            identity_fetch_error(reqwest::StatusCode::INTERNAL_SERVER_ERROR, "boom"),
+            PatreonError::Api(_)
+        ));
     }
 
     #[test]
@@ -1515,6 +1663,60 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn merge_refreshed_link_preserves_identity_and_updates_tokens() {
+        let sealer = TokenSealer::Plaintext;
+        let old = consumer_link_with_token(&sealer, b"old-access").await;
+        let new_tokens = PatreonTokenResponse {
+            access_token: "new-access".into(),
+            refresh_token: "new-refresh".into(),
+            expires_in: 2_592_000,
+            scope: "identity campaigns.members".into(),
+            token_type: "Bearer".into(),
+        };
+        let sealed_access = sealer
+            .seal(new_tokens.access_token.as_bytes())
+            .await
+            .unwrap();
+        let sealed_refresh = seal_under_existing_dek(
+            &sealer,
+            &sealed_access.wrapped_dek,
+            new_tokens.refresh_token.as_bytes(),
+        )
+        .await
+        .unwrap();
+        let now = 1_000_000;
+        let merged = merge_refreshed_link(&old, &new_tokens, sealed_access, sealed_refresh, now);
+
+        // Identity, role, and link timestamp are preserved.
+        assert_eq!(merged.user_id, old.user_id);
+        assert_eq!(merged.patreon_user_id, old.patreon_user_id);
+        assert_eq!(merged.role, old.role);
+        assert_eq!(merged.campaign_id, old.campaign_id);
+        assert_eq!(merged.linked_at, old.linked_at);
+        // Token material + expiry + scopes are refreshed.
+        assert_eq!(merged.scopes, "identity campaigns.members");
+        assert_eq!(merged.token_expires_at, now + 2_592_000);
+        let opened_access = sealer
+            .open(&SealedToken {
+                wrapped_dek: merged.wrapped_dek.clone(),
+                nonce: merged.access_token_nonce.clone(),
+                ciphertext: merged.access_token_ct.clone(),
+            })
+            .await
+            .unwrap();
+        assert_eq!(opened_access, b"new-access");
+        let opened_refresh = sealer
+            .open(&SealedToken {
+                wrapped_dek: merged.wrapped_dek.clone(),
+                nonce: merged.refresh_token_nonce.clone(),
+                ciphertext: merged.refresh_token_ct.clone(),
+            })
+            .await
+            .unwrap();
+        assert_eq!(opened_refresh, b"new-refresh");
+    }
+
+    #[tokio::test]
     async fn consumer_fetch_failure_propagates_does_not_yield_empty_snapshot() {
         // Fail-closed contract: when Patreon is unreachable, materialization
         // must return Err (so materialize_for_user omits the claim and does NOT
@@ -1533,12 +1735,114 @@ mod tests {
             sealer: Some(sealer),
             http: unreachable_patreon_http(),
             cache: MembershipCache::new(redis),
+            token_url: PATREON_TOKEN_URL.to_string(),
+            identity_url: PATREON_IDENTITY_URL.to_string(),
         };
         let result = materialize_from_link(&state, &link).await;
         assert!(
             result.is_err(),
             "unreachable Patreon must propagate an error, got: {result:?}"
         );
+    }
+
+    /// Minimal localhost Patreon stand-in. Dispatches on method + bearer token:
+    /// - POST (token endpoint)            → 200, rotated tokens (new-access/new-refresh)
+    /// - GET  with `Bearer old-access`    → 401 (token expired)
+    /// - GET  with `Bearer new-access`    → 200, one active membership
+    ///
+    /// Returns `(token_url, identity_url)` pointing at the spawned server.
+    async fn spawn_patreon_mock() -> (String, String) {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            loop {
+                let (mut sock, _) = match listener.accept().await {
+                    Ok(c) => c,
+                    Err(_) => break,
+                };
+                tokio::spawn(async move {
+                    // Small localhost requests arrive whole in one read; the
+                    // request line + headers are all we dispatch on.
+                    let mut buf = vec![0u8; 8192];
+                    let n = sock.read(&mut buf).await.unwrap_or(0);
+                    let req = String::from_utf8_lossy(&buf[..n]).to_string();
+                    let is_post = req.starts_with("POST");
+                    let has_old = req.contains("Bearer old-access");
+
+                    let (status_line, body) = if is_post {
+                        (
+                            "HTTP/1.1 200 OK",
+                            r#"{"access_token":"new-access","refresh_token":"new-refresh","expires_in":2592000,"scope":"identity","token_type":"Bearer"}"#.to_string(),
+                        )
+                    } else if has_old {
+                        ("HTTP/1.1 401 Unauthorized", String::new())
+                    } else {
+                        (
+                            "HTTP/1.1 200 OK",
+                            r#"{"data":{"id":"p-1"},"included":[{"type":"member","id":"m1","attributes":{"patron_status":"active_patron"},"relationships":{"campaign":{"data":{"id":"camp-1"}},"currently_entitled_tiers":{"data":[{"id":"tier-gold"}]}}}]}"#.to_string(),
+                        )
+                    };
+                    let resp = format!(
+                        "{status_line}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+                        body.len()
+                    );
+                    let _ = sock.write_all(resp.as_bytes()).await;
+                    let _ = sock.flush().await;
+                });
+            }
+        });
+        let base = format!("http://{addr}");
+        (format!("{base}/token"), format!("{base}/v2/identity"))
+    }
+
+    #[tokio::test]
+    async fn consumer_membership_refreshes_on_401_and_retries() {
+        // End-to-end: stale access token → 401 → refresh → retry → memberships.
+        let (token_url, identity_url) = spawn_patreon_mock().await;
+        let sealer = TokenSealer::Plaintext;
+        let link = consumer_link_with_token(&sealer, b"old-access").await;
+        let redis =
+            fred::clients::RedisClient::new(fred::types::RedisConfig::default(), None, None, None);
+        let state = PatreonState {
+            oauth: Some(PatreonOAuthConfig {
+                client_id: "c".into(),
+                client_secret: "s".into(),
+                redirect_uris: vec!["https://x/cb".into()],
+            }),
+            sealer: Some(sealer.clone()),
+            http: reqwest::Client::new(),
+            cache: MembershipCache::new(redis),
+            token_url,
+            identity_url,
+        };
+
+        let (snap, refreshed) = materialize_from_link(&state, &link)
+            .await
+            .expect("materialization should succeed after refresh");
+
+        // The retried fetch (with new-access) returned the active membership.
+        assert_eq!(snap.memberships.len(), 1, "expected one membership");
+        assert_eq!(
+            snap.memberships[0].patron_status.as_deref(),
+            Some("active_patron")
+        );
+        assert_eq!(snap.memberships[0].tier_ids, vec!["tier-gold"]);
+
+        // A refresh occurred, so a rotated link is handed back for persistence,
+        // and its access ciphertext decrypts to the new token.
+        let new_link = refreshed.expect("a refresh should have produced a new link");
+        assert_eq!(new_link.user_id, link.user_id);
+        assert_eq!(new_link.patreon_user_id, link.patreon_user_id);
+        let opened = sealer
+            .open(&SealedToken {
+                wrapped_dek: new_link.wrapped_dek.clone(),
+                nonce: new_link.access_token_nonce.clone(),
+                ciphertext: new_link.access_token_ct.clone(),
+            })
+            .await
+            .unwrap();
+        assert_eq!(opened, b"new-access");
     }
 
     #[tokio::test]


### PR DESCRIPTION
Mirrors the Apple linking pattern for Patreon as an upstream
identity/entitlement source.

- New POST /oauth/patreon/link endpoint (auth-required, single endpoint
  by design — no /me/patreon or /entitlements surface). Server does the
  Patreon code exchange, discovers patreon_user_id / campaign_id,
  writes identity_links (conditional put for per-Patreon-account
  uniqueness, idempotent re-link, 409 on cross-account conflict) and a
  new patreon_tokens row keyed by arkavo user_id.
- KMS envelope encryption: per-row AES-256-GCM DEK wrapped by
  PATREON_KMS_KEY_ID. Distinct GCM nonces per access/refresh ciphertext.
- arkavo_patreon CWT claim added to oidc access_token only — no
  separate entitlement endpoint. Materialized via Patreon
  /api/oauth2/v2/identity on token mint, cached 5 min in Redis (with
  in-memory fallback). Fail-closed: missing/stale/Patreon-down ⇒ omit
  the claim, KAS/policy treats absence as "no entitlement".
- Patreon support is fully optional: any of PATREON_CLIENT_ID,
  PATREON_CLIENT_SECRET, PATREON_REDIRECT_URIS, PATREON_KMS_KEY_ID
  unset ⇒ all Patreon paths disabled, link endpoint returns 503.

https://claude.ai/code/session_01S615CZitYt6bQ6MV1zMzUR