### PR TITLE
feat(oidc): drop arkavo_ prefix from CWT discovery extensions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -320,7 +320,7 @@ aws dynamodb create-table \
   - `/.well-known/jwks.json` — JWKS for `id_token` verifiers (OIDC RPs).
   - `/.well-known/cose-keys` — COSE_Key Set for CWT verifiers (OpenTDF, native).
   - Same `kid` (RFC 7638 thumbprint) in both formats — JWKS advertises the base64url-encoded form; COSE_Key uses raw 32-byte hash.
-- **Discovery doc** (`/.well-known/openid-configuration`) advertises `arkavo_access_token_format: "application/cwt"` and `arkavo_cose_keys_uri` for CWT-aware RPs.
+- **Discovery doc** (`/.well-known/openid-configuration`) advertises `access_token_format: "application/cwt"` and `cose_keys_uri` for CWT-aware RPs.
 - **PoP**: `cnf` claim (RFC 8747) populated bound-at-issuance with the WebAuthn passkey COSE_Key or App Attest key where available. Not verifier-enforced in this release.
 
 **WebAuthn Protection**:

--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -98,10 +98,8 @@ pub struct DiscoveryDocument {
     pub claims_supported: Vec<&'static str>,
     pub grant_types_supported: Vec<&'static str>,
     pub code_challenge_methods_supported: Vec<&'static str>,
-    #[serde(rename = "arkavo_access_token_format")]
-    pub arkavo_access_token_format: String,
-    #[serde(rename = "arkavo_cose_keys_uri")]
-    pub arkavo_cose_keys_uri: String,
+    pub access_token_format: String,
+    pub cose_keys_uri: String,
 }
 
 /// OIDC claims issued in ID/access tokens.
@@ -530,8 +528,8 @@ pub async fn discovery(Extension(oidc): Extension<Arc<OidcConfig>>) -> impl Into
         ],
         grant_types_supported: vec!["authorization_code", "client_credentials", "refresh_token"],
         code_challenge_methods_supported: vec!["S256"],
-        arkavo_access_token_format: "application/cwt".to_string(),
-        arkavo_cose_keys_uri: format!(
+        access_token_format: "application/cwt".to_string(),
+        cose_keys_uri: format!(
             "{}/.well-known/cose-keys",
             oidc.issuer.trim_end_matches('/')
         ),
@@ -2008,8 +2006,8 @@ mod tests {
                 .any(|c| c == "arkavo_entitlements")
         );
         // Extension fields for CWT-aware RPs
-        assert_eq!(v["arkavo_access_token_format"], "application/cwt");
-        let cose_uri = v["arkavo_cose_keys_uri"].as_str().expect("string");
+        assert_eq!(v["access_token_format"], "application/cwt");
+        let cose_uri = v["cose_keys_uri"].as_str().expect("string");
         assert!(
             cose_uri.ends_with("/.well-known/cose-keys"),
             "unexpected cose_uri: {}",
@@ -2018,7 +2016,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn discovery_doc_includes_arkavo_extensions() {
+    async fn discovery_doc_includes_cwt_extensions() {
         let oidc = test_oidc_config();
         let app = Router::new()
             .route("/.well-known/openid-configuration", get(discovery))
@@ -2040,10 +2038,10 @@ mod tests {
             .unwrap();
         let body_json: serde_json::Value = serde_json::from_slice(&body).expect("valid JSON");
 
-        assert_eq!(body_json["arkavo_access_token_format"], "application/cwt");
-        let uri = body_json["arkavo_cose_keys_uri"]
+        assert_eq!(body_json["access_token_format"], "application/cwt");
+        let uri = body_json["cose_keys_uri"]
             .as_str()
-            .expect("arkavo_cose_keys_uri must be a string");
+            .expect("cose_keys_uri must be a string");
         assert!(uri.ends_with("/.well-known/cose-keys"), "got {}", uri);
         assert_eq!(uri, "https://identity.arkavo.net/.well-known/cose-keys");
     }


### PR DESCRIPTION
## Summary

- Rename `arkavo_cose_keys_uri` → `cose_keys_uri` in the OIDC discovery doc.
- Rename `arkavo_access_token_format` → `access_token_format` in the OIDC discovery doc.
- These are vendor extensions to OIDC Discovery; there's no realistic competing claim with the unprefixed names, and dropping the prefix is what consumers expect.

## Coordination

This is the **publisher** side. Ship this before (or in lockstep with) the matching consumer change in `arkavo-org/opentdf-platform`, since that side's `newTokenVerifier` refuses to start if it can't find `cose_keys_uri` in discovery.

## Test plan

- [x] `cargo build --bin authnz-rs` — clean (2 pre-existing dead-code warnings, unrelated)
- [x] `cargo test --bin authnz-rs oidc::` — 26/26 pass (including the renamed `discovery_doc_includes_cwt_extensions` test)
- [ ] Smoke `curl https://identity.arkavo.net/.well-known/openid-configuration` after deploy and confirm the unprefixed names appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)