### PR TITLE
feat(oidc): optional shared platform audience on access tokens

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,12 @@ export OIDC_CLIENT_OPENTDF_REDIRECT_URIS=https://opentdf.example/callback,https:
 # export OIDC_CLIENT_ARKAVOIOS_ID=arkavo-ios
 # export OIDC_CLIENT_ARKAVOIOS_REDIRECT_URIS=arkavo://oauth/cb
 
+# Optional: shared resource audience appended to every OIDC access token
+# (RFC 8707-style). Set this to the OpenTDF platform's configured audience so
+# tokens minted for any RP (apps, service accounts) pass the platform's
+# single-audience CWT verification. Unset = single-audience tokens.
+export OIDC_PLATFORM_AUDIENCE=https://platform.arkavo.net
+
 # Optional: Sign in with Apple. Accepts a comma-separated list so the same
 # AuthNZ instance can serve an iOS bundle id + web Service ID.
 export APPLE_CLIENT_ID=com.arkavo.app,com.arkavo.web

--- a/src/main.rs
+++ b/src/main.rs
@@ -185,6 +185,13 @@ pub struct AppState {
     /// (falling back to [`crate::constants::DEFAULT_OIDC_ISSUER`]) so mint
     /// and verify always agree on a single value within a process.
     pub issuer: Arc<String>,
+    /// Optional shared audience appended to every OIDC access token
+    /// (`OIDC_PLATFORM_AUDIENCE`, e.g. "https://platform.arkavo.net").
+    /// Access tokens normally carry `aud = client_id`, but a resource server
+    /// validating one fixed audience (the OpenTDF platform's CWT verifier)
+    /// must accept tokens minted for any RP — RFC 8707-style. None ⇒
+    /// single-audience tokens, unchanged.
+    pub platform_audience: Arc<Option<String>>,
 }
 
 #[tokio::main]
@@ -287,6 +294,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         cwt_verifying_key: Arc::new(cwt_verifying_key),
         cwt_kid: Arc::new(cwt_kid),
         issuer: Arc::new(issuer),
+        platform_audience: Arc::new(
+            env::var("OIDC_PLATFORM_AUDIENCE")
+                .ok()
+                .filter(|v| !v.is_empty()),
+        ),
     };
 
     // Set up Redis Client using fred
@@ -1150,6 +1162,7 @@ pub(crate) mod test_helpers {
             cwt_verifying_key: Arc::new(cwt_verifying_key),
             cwt_kid: Arc::new(cwt_kid),
             issuer: Arc::new(crate::constants::DEFAULT_OIDC_ISSUER.to_string()),
+            platform_audience: Arc::new(None),
         }
     }
 }

--- a/src/oidc.rs
+++ b/src/oidc.rs
@@ -1729,6 +1729,17 @@ pub fn mint_access_token(
 ) -> Result<String, crate::cwt::CwtError> {
     let mut claims = crate::cwt::ArkavoClaims::oidc_access(&app_state.issuer, sub, audience, 1);
 
+    // RFC 8707-style shared resource audience: a resource server validating
+    // one fixed audience (the OpenTDF platform CWT verifier) must accept
+    // tokens minted for any RP, so the configured platform audience rides
+    // along with the per-client one.
+    if let Some(platform_aud) = app_state.platform_audience.as_ref()
+        && platform_aud != audience
+    {
+        claims.aud =
+            crate::cwt::Audience::Multiple(vec![audience.to_string(), platform_aud.clone()]);
+    }
+
     if let Some(e) = extras {
         if !e.idp.is_empty() {
             claims = claims.with_idp(&e.idp);
@@ -2257,6 +2268,7 @@ mod tests {
             cwt_verifying_key: Arc::new(cwt_verifying_key),
             cwt_kid: Arc::new(cwt_kid),
             issuer: Arc::new("https://identity.arkavo.net".to_string()),
+            platform_audience: Arc::new(None),
         };
 
         let mut oidc = (*test_oidc_config()).clone();
@@ -2353,6 +2365,7 @@ mod tests {
             cwt_verifying_key: Arc::new(cwt_verifying_key),
             cwt_kid: Arc::new(cwt_kid),
             issuer: Arc::new("https://identity.arkavo.net".to_string()),
+            platform_audience: Arc::new(None),
         };
 
         let mut oidc = (*test_oidc_config()).clone();
@@ -2443,6 +2456,53 @@ mod tests {
         let claims = crate::cwt::claims_from_cbor(sign1.payload.as_ref().unwrap()).unwrap();
         assert_eq!(claims.aud, crate::cwt::Audience::Single("opentdf".into()));
         assert_eq!(claims.custom.idp.as_deref(), Some("arkavo"));
+    }
+
+    #[tokio::test]
+    async fn access_token_carries_platform_audience_when_configured() {
+        use coset::CborSerializable;
+        unsafe {
+            std::env::set_var("AWS_REGION", "us-east-1");
+            std::env::set_var("AWS_ACCESS_KEY_ID", "test");
+            std::env::set_var("AWS_SECRET_ACCESS_KEY", "test");
+        }
+
+        let mut app_state = crate::test_helpers::build_test_app_state().await;
+        app_state.platform_audience =
+            std::sync::Arc::new(Some("https://platform.arkavo.net".to_string()));
+
+        let token =
+            crate::oidc::mint_access_token(&app_state, "arkavo:test", "opentdf", None, None)
+                .expect("mint");
+        let raw = crate::cwt::decode_from_header(&token).unwrap();
+        let inner = crate::cwt::strip_cwt_tag(&raw).expect("CWT tag");
+        let sign1 = coset::CoseSign1::from_slice(inner).unwrap();
+        let claims = crate::cwt::claims_from_cbor(sign1.payload.as_ref().unwrap()).unwrap();
+        assert_eq!(
+            claims.aud,
+            crate::cwt::Audience::Multiple(vec![
+                "opentdf".to_string(),
+                "https://platform.arkavo.net".to_string()
+            ])
+        );
+
+        // When the client IS the platform audience, no duplicate aud entry.
+        let token = crate::oidc::mint_access_token(
+            &app_state,
+            "arkavo:test",
+            "https://platform.arkavo.net",
+            None,
+            None,
+        )
+        .expect("mint");
+        let raw = crate::cwt::decode_from_header(&token).unwrap();
+        let inner = crate::cwt::strip_cwt_tag(&raw).expect("CWT tag");
+        let sign1 = coset::CoseSign1::from_slice(inner).unwrap();
+        let claims = crate::cwt::claims_from_cbor(sign1.payload.as_ref().unwrap()).unwrap();
+        assert_eq!(
+            claims.aud,
+            crate::cwt::Audience::Single("https://platform.arkavo.net".into())
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Deployment unblock for the entitled catalog (arkavo-org/tdf-iroh-s3#5, deploy step 2).

## Problem

The OpenTDF platform's CWT verifier validates **one** configured audience; authnz access tokens mint `aud = client_id` (single). User tokens (aud = the app's RP id) and the catalog node's service-account token (aud = its own client id) can never both pass the same platform audience check — so either KAS rewrap or authorization.v2 decisions would fail audience validation in production.

## Change

New optional `OIDC_PLATFORM_AUDIENCE` env. When set (e.g. `https://platform.arkavo.net`), every OIDC access token carries `aud = [client_id, platform_audience]` — RFC 8707-style resource audience — deduplicated when the client *is* the platform audience. Unset ⇒ behavior unchanged (single audience).

The platform side already accepts multi-valued `aud` (`audienceContains` handles string arrays), and `Audience::Multiple` was already in cwt.rs — this just wires it into `mint_access_token` (all three grants inherit: code, refresh, client_credentials).

## Notes for deployment

- Platform upstream config sets `server.auth.audience: https://platform.arkavo.net`.
- The catalog node uses a client_credentials CWT (carries `arkavo_roles: ["service-account"]`); platform maps it via `groups_claim: arkavo_roles` + `policy.map`.

Suite 160 passing; no new clippy warnings (the 6 pre-existing are unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)