### PR TITLE
feat(http3): functional HTTP/3 (QUIC)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ hyper-util = { version = "0.1", features = ["tokio", "server", "server-auto"] }
 h3 = { version = "0.0.8", optional = true }
 h3-quinn = { version = "0.0.10", optional = true }
 quinn = { version = "0.11", optional = true }
+http-body = { version = "1", optional = true }         # response body size_hint for H3 Content-Length
 http-body-util = { version = "0.1", optional = true }  # frame-by-frame H3 response streaming
 webauthn-rs = { version = "0.5", features = ["danger-allow-state-serialisation"] }
 tower = { version = "0.5", features = ["full"] }
@@ -63,6 +64,6 @@ didwebvh-rs = { version = "0.5.5", default-features = false, optional = true }
 
 [features]
 default = []
-http3 = ["h3", "h3-quinn", "quinn", "http-body-util"]
+http3 = ["h3", "h3-quinn", "quinn", "http-body", "http-body-util"]
 # did:webvh log engine (DIF didwebvh-rs). Heavy deps, so opt-in.
 webvh = ["dep:didwebvh-rs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "authnz-rs"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2024"
 license = "BSD-2"
 rust-version = "1.95"  # raised from 1.91.1 for didwebvh-rs 0.5.5 (webvh feature)
@@ -20,8 +20,8 @@ rustls-pemfile = "2.2"
 hyper = { version = "1", features = ["server", "http1", "http2"] }
 hyper-util = { version = "0.1", features = ["tokio", "server", "server-auto"] }
 # HTTP/3 support (optional - enable with "http3" feature)
-h3 = { version = "0.0.6", optional = true }
-h3-quinn = { version = "0.0.8", optional = true }
+h3 = { version = "0.0.8", optional = true }
+h3-quinn = { version = "0.0.10", optional = true }
 quinn = { version = "0.11", optional = true }
 webauthn-rs = { version = "0.5", features = ["danger-allow-state-serialisation"] }
 tower = { version = "0.5", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ hyper-util = { version = "0.1", features = ["tokio", "server", "server-auto"] }
 h3 = { version = "0.0.8", optional = true }
 h3-quinn = { version = "0.0.10", optional = true }
 quinn = { version = "0.11", optional = true }
+http-body-util = { version = "0.1", optional = true }  # frame-by-frame H3 response streaming
 webauthn-rs = { version = "0.5", features = ["danger-allow-state-serialisation"] }
 tower = { version = "0.5", features = ["full"] }
 tower-sessions = "0.12"
@@ -62,6 +63,6 @@ didwebvh-rs = { version = "0.5.5", default-features = false, optional = true }
 
 [features]
 default = []
-http3 = ["h3", "h3-quinn", "quinn"]
+http3 = ["h3", "h3-quinn", "quinn", "http-body-util"]
 # did:webvh log engine (DIF didwebvh-rs). Heavy deps, so opt-in.
 webvh = ["dep:didwebvh-rs"]

--- a/docs/superpowers/plans/2026-06-20-http3-quinn-bridge.md
+++ b/docs/superpowers/plans/2026-06-20-http3-quinn-bridge.md
@@ -1,0 +1,389 @@
+# HTTP/3 (QUIC) Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the feature-gated HTTP/3 (QUIC) server compile and route real requests through the existing Axum `Router`, alongside HTTP/2, with `Alt-Svc` advertisement.
+
+**Architecture:** Bump the `h3`/`h3-quinn` dependency set so `h3-quinn` builds against the `quinn 0.11.9` that resolves today (clears the private-`StreamId` error and the `h3` version skew). Port the three feature-gated H3 functions in `src/main.rs` from the `h3 0.0.6` API to `0.0.8` (`accept()` → `RequestResolver::resolve_request()`, new `RequestStream<BidiStream<Bytes>, Bytes>` generics, `quinn::Endpoint::new`). Replace the stub `handle_h3_request` with a real H3→Axum bridge: collect the request body, drive the `Router` via `tower::ServiceExt::oneshot`, stream status/headers/body back over the H3 stream. Advertise `Alt-Svc: h3` from the TCP (HTTP/1.1+HTTP/2) response path when H3 is actually serving.
+
+**Tech Stack:** Rust 1.95 (MSRV), Axum 0.7, Tower 0.5, h3 0.0.8, h3-quinn 0.0.10, quinn 0.11.9, hyper/hyper-util, rustls 0.23.
+
+## Global Constraints
+
+- MSRV: Rust 1.95 (`Cargo.toml` `rust-version = "1.95"`) — do not use APIs newer than this.
+- The default build (no `http3` feature) and the existing HTTP/1.1 + HTTP/2 paths MUST remain byte-for-byte unchanged in behavior. All new code is `#[cfg(feature = "http3")]`-gated except the runtime-gated `Alt-Svc` layer, which is a no-op unless the `http3` feature is compiled AND `ENABLE_HTTP3` is on AND TLS is enabled.
+- `Cargo.lock` is gitignored — do not attempt to commit it.
+- All H3 dependency declarations stay `optional = true` under the `http3` feature.
+- Do not use `--release` during development (`opt-level`/codegen settings make it slow); use plain `cargo build --features http3`.
+- Verified facts (2026-06-20, `main` @ 48f9120, Rust 1.96.0 toolchain, MSRV 1.95): `h3 0.0.8` + `h3-quinn 0.0.10` (requires `h3 ^0.0.8`, `quinn ^0.11.7`) + `quinn 0.11` collapse to a single `h3 0.0.8` / `quinn 0.11.9` / `quinn-proto 0.11.13`; `h3-quinn 0.0.10` compiles cleanly against `quinn 0.11.9` (no `StreamId` error).
+
+---
+
+### Task 1: Bump the HTTP/3 dependency set (clears Blocker 1)
+
+**Files:**
+- Modify: `Cargo.toml:22-25` (`h3`, `h3-quinn` version strings)
+- Modify: `Cargo.toml:3` (package version bump)
+
+**Interfaces:**
+- Produces: a dependency graph where `cargo tree --features http3` shows a single `h3 0.0.8`, `h3-quinn 0.0.10`, `quinn 0.11.9`.
+
+- [ ] **Step 1: Bump the dep versions**
+
+```toml
+# HTTP/3 support (optional - enable with "http3" feature)
+h3 = { version = "0.0.8", optional = true }
+h3-quinn = { version = "0.0.10", optional = true }
+quinn = { version = "0.11", optional = true }
+```
+
+- [ ] **Step 2: Bump the package version (new feature → minor bump)**
+
+```toml
+version = "0.7.0"
+```
+
+- [ ] **Step 3: Verify the tree collapses to a single h3**
+
+Run: `cargo tree --features http3 2>/dev/null | grep -oE "h3 v[0-9.]+" | sort -u`
+Expected: exactly `h3 v0.0.8` (one line).
+
+- [ ] **Step 4: Verify h3-quinn compiles against quinn (the StreamId error is gone)**
+
+Run: `cargo build --features http3 2>&1 | grep -E "StreamId|could not compile .h3-quinn"`
+Expected: NO output (h3-quinn compiles; remaining errors are in `authnz-rs` itself and are fixed in Tasks 2–3).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Cargo.toml
+git commit -m "build(http3): bump h3 0.0.8 / h3-quinn 0.0.10 to compile against quinn 0.11.9; bump to 0.7.0"
+```
+
+---
+
+### Task 2: Port the H3 server functions to the 0.0.8 API
+
+**Files:**
+- Modify: `src/main.rs:96-103` (`quinn::Endpoint` construction in `run_h3_server`)
+- Modify: `src/main.rs:123-149` (`handle_h3_connection` accept loop)
+- Modify: `src/main.rs:151-155` (`handle_h3_request` signature)
+
+**Interfaces:**
+- Consumes: the bumped deps from Task 1.
+- Produces: `handle_h3_request(req: http::Request<()>, stream: h3::server::RequestStream<h3_quinn::BidiStream<bytes::Bytes>, bytes::Bytes>, app: Router)` — the exact stream type Task 3's bridge body relies on.
+
+API changes being applied (verified against the installed crate sources):
+- `quinn::Endpoint::new_with_abstract_socket(cfg, Some(scfg), socket.try_into()?, rt)` → `quinn::Endpoint::new(cfg, Some(scfg), socket, rt)` (takes `std::net::UdpSocket` directly; `new_with_abstract_socket` now requires `Arc<dyn AsyncUdpSocket>`).
+- `h3_conn.accept()` now returns `Result<Option<RequestResolver<C, B>>, ConnectionError>` (was the `(Request, RequestStream)` tuple). Call `resolver.resolve_request().await` → `Result<(Request<()>, RequestStream<...>), StreamError>`.
+- `RequestStream`'s first generic is the buffer type: `h3_quinn::BidiStream<bytes::Bytes>` (was `h3_quinn::BidiStream<h3_quinn::RecvStream>`).
+
+- [ ] **Step 1: Fix the Endpoint construction in `run_h3_server`**
+
+Replace `src/main.rs:97-103`:
+
+```rust
+    // Bind UDP socket
+    let socket = std::net::UdpSocket::bind(addr)?;
+    let endpoint = quinn::Endpoint::new(
+        quinn::EndpointConfig::default(),
+        Some(quinn_server_config),
+        socket,
+        Arc::new(quinn::TokioRuntime),
+    )?;
+```
+
+- [ ] **Step 2: Port the accept loop in `handle_h3_connection`**
+
+Replace the body of the `loop` in `src/main.rs:130-146`:
+
+```rust
+    loop {
+        match h3_conn.accept().await {
+            Ok(Some(resolver)) => {
+                let app = app.clone();
+                tokio::spawn(async move {
+                    match resolver.resolve_request().await {
+                        Ok((req, stream)) => {
+                            if let Err(e) = handle_h3_request(req, stream, app).await {
+                                eprintln!("HTTP/3 request error: {}", e);
+                            }
+                        }
+                        Err(e) => eprintln!("HTTP/3 request resolve error: {}", e),
+                    }
+                });
+            }
+            Ok(None) => break,
+            Err(e) => {
+                eprintln!("HTTP/3 accept error: {}", e);
+                break;
+            }
+        }
+    }
+```
+
+- [ ] **Step 3: Fix the `handle_h3_request` signature (buffer generic)**
+
+Replace `src/main.rs:152-156`:
+
+```rust
+#[cfg(feature = "http3")]
+async fn handle_h3_request(
+    req: http::Request<()>,
+    mut stream: h3::server::RequestStream<h3_quinn::BidiStream<bytes::Bytes>, bytes::Bytes>,
+    app: Router,
+) -> Result<(), Box<dyn std::error::Error>> {
+```
+
+(The body is replaced by Task 3; after this step it still references the stub return.)
+
+- [ ] **Step 4: Verify only the stub-body errors remain**
+
+Run: `cargo build --features http3 2>&1 | grep -E "error\[|error:" | grep -v "handle_h3_request" | head`
+Expected: the `Endpoint`, `accept`, and signature errors are gone. (The build may still fail inside `handle_h3_request`'s old stub body — that is fixed in Task 3.)
+
+---
+
+### Task 3: Implement the H3 → Axum bridge (replaces the stub)
+
+**Files:**
+- Modify: `src/main.rs:156-170` (body of `handle_h3_request`)
+- Modify: `src/main.rs:25` area (add `use tower::ServiceExt;` for `oneshot`)
+
+**Interfaces:**
+- Consumes: `handle_h3_request` signature from Task 2; `app: Router` implements `Service<Request<axum::body::Body>>`.
+- Produces: real HTTP responses over H3 for every route.
+
+Bridge design (verified APIs): `RequestStream::recv_data()` → `Result<Option<impl Buf>, StreamError>`; `send_response(Response<()>)`, `send_data(Bytes)`, `finish()`. Drive the router with `tower::ServiceExt::oneshot` (error type `Infallible`). Collect the response body with `axum::body::to_bytes` (no extra dependency; auth/OIDC responses are small). Cap the request body to guard memory.
+
+- [ ] **Step 1: Add the `oneshot` import**
+
+Near the other `tower` imports (`src/main.rs:25-26`):
+
+```rust
+use tower::Service;
+use tower::ServiceBuilder;
+use tower::ServiceExt; // for Router::oneshot in the HTTP/3 bridge
+```
+
+- [ ] **Step 2: Replace the stub body of `handle_h3_request`**
+
+Replace everything from the comment `// Convert H3 request to Axum request` through `Ok(())` (the old `src/main.rs:157-169`) with:
+
+```rust
+    use bytes::Buf;
+
+    // 1. Collect the H3 request body into an axum Body (bounded).
+    const MAX_H3_BODY: usize = 2 * 1024 * 1024; // 2 MiB — auth/OIDC payloads are tiny
+    let mut body_bytes: Vec<u8> = Vec::new();
+    while let Some(mut chunk) = stream.recv_data().await? {
+        let remaining = chunk.remaining();
+        if body_bytes.len() + remaining > MAX_H3_BODY {
+            // Refuse oversized bodies rather than buffering unbounded.
+            let resp = http::Response::builder()
+                .status(StatusCode::PAYLOAD_TOO_LARGE)
+                .body(())
+                .unwrap();
+            stream.send_response(resp).await?;
+            stream.finish().await?;
+            return Ok(());
+        }
+        body_bytes.extend_from_slice(chunk.copy_to_bytes(remaining).as_ref());
+    }
+
+    let (parts, _) = req.into_parts();
+    let axum_req = http::Request::from_parts(parts, axum::body::Body::from(body_bytes));
+
+    // 2. Drive the Axum router as a tower::Service (error is Infallible).
+    let response = app
+        .oneshot(axum_req)
+        .await
+        .map_err(|e| format!("router error: {e}"))?;
+
+    // 3. Stream status + headers + body back over the H3 stream.
+    let (resp_parts, resp_body) = response.into_parts();
+    let h3_response = http::Response::from_parts(resp_parts, ());
+    stream.send_response(h3_response).await?;
+
+    let body_bytes = axum::body::to_bytes(resp_body, usize::MAX).await?;
+    if !body_bytes.is_empty() {
+        stream.send_data(body_bytes).await?;
+    }
+    stream.finish().await?;
+
+    Ok(())
+```
+
+- [ ] **Step 3: Verify the http3 build now succeeds**
+
+Run: `cargo build --features http3 2>&1 | tail -5`
+Expected: `Finished ...` (no errors).
+
+- [ ] **Step 4: Verify the default build is unchanged**
+
+Run: `cargo build 2>&1 | tail -3`
+Expected: `Finished ...` (no errors, no new warnings introduced by H3 code, which is feature-gated out).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main.rs
+git commit -m "feat(http3): port h3 server to 0.0.8 API and bridge H3 requests to the Axum router"
+```
+
+---
+
+### Task 4: Advertise `Alt-Svc` + unit test + clean up the `h3_addr` move bug
+
+**Files:**
+- Modify: `src/main.rs` — add `alt_svc_header_value` helper + conditional middleware layer
+- Modify: `src/main.rs:435-445` — fix the pre-existing `borrow of moved value: h3_addr` (clone before the spawned closure consumes it)
+- Modify: `src/main.rs` `#[cfg(test)] mod tests` — add a unit test for the Alt-Svc helper
+
+**Interfaces:**
+- Consumes: `settings.port` for the advertised port.
+- Produces: `alt_svc_header_value(port: u16) -> http::HeaderValue`.
+
+- [ ] **Step 1: Write the failing test for the Alt-Svc helper**
+
+Add to the `#[cfg(test)] mod tests` block in `src/main.rs`:
+
+```rust
+    #[test]
+    fn alt_svc_header_advertises_h3_on_port() {
+        let v = alt_svc_header_value(443);
+        assert_eq!(v.to_str().unwrap(), "h3=\":443\"; ma=86400");
+        let v8443 = alt_svc_header_value(8443);
+        assert_eq!(v8443.to_str().unwrap(), "h3=\":8443\"; ma=86400");
+    }
+```
+
+- [ ] **Step 2: Run it to confirm it fails to compile (helper undefined)**
+
+Run: `cargo test alt_svc_header_advertises_h3_on_port 2>&1 | grep -E "cannot find function|error\[E0425\]" | head`
+Expected: an error that `alt_svc_header_value` is not found.
+
+- [ ] **Step 3: Add the helper (always compiled — it is plain axum/http, no h3 deps)**
+
+Add near `handler_fallback` in `src/main.rs`:
+
+```rust
+/// Build the `Alt-Svc` header value advertising HTTP/3 on the given port.
+fn alt_svc_header_value(port: u16) -> http::HeaderValue {
+    // `ma` (max-age) is advisory; 86400s = 24h is a common, conservative value.
+    http::HeaderValue::from_str(&format!("h3=\":{}\"; ma=86400", port))
+        .expect("alt-svc header value is always valid ASCII")
+}
+```
+
+- [ ] **Step 4: Run the test to confirm it passes**
+
+Run: `cargo test alt_svc_header_advertises_h3_on_port 2>&1 | tail -5`
+Expected: `test ... ok` / `test result: ok`.
+
+- [ ] **Step 5: Fix the pre-existing `h3_addr` move bug and apply the layer conditionally**
+
+In the TLS branch, fix the move (clone `h3_addr` for the `println!` after the spawn), `src/main.rs:435-446`:
+
+```rust
+            let h3_addr = format!("{}:{}", settings.bind_address, settings.port);
+            let h3_app = app.clone();
+            let h3_cert_path = settings.tls_cert_path.clone();
+            let h3_key_path = settings.tls_key_path.clone();
+
+            let log_addr = h3_addr.clone();
+            tokio::spawn(async move {
+                if let Err(e) = run_h3_server(&h3_addr, h3_app, &h3_cert_path, &h3_key_path).await {
+                    eprintln!("HTTP/3 server error: {}", e);
+                }
+            });
+            println!("HTTP/3 (QUIC) enabled on UDP {}", log_addr);
+```
+
+Then, right after the `app` router is fully built (after the `.fallback(handler_fallback);` at `src/main.rs:424`), add the conditional Alt-Svc layer. Because the layer must wrap the same `app` that both the TCP and H3 paths clone, add it before `let addr = ...`:
+
+```rust
+    // Advertise HTTP/3 via Alt-Svc on the TCP (HTTP/1.1+HTTP/2) responses, but
+    // only when H3 is actually serving: feature compiled in, runtime toggle on,
+    // and TLS enabled (H3 only runs in the TLS branch). No-op for the default
+    // build, keeping the non-http3 path unchanged.
+    let advertise_h3 = cfg!(feature = "http3")
+        && settings.tls_enabled
+        && env::var("ENABLE_HTTP3").unwrap_or_else(|_| "true".to_string()) == "true";
+    let app = if advertise_h3 {
+        let alt_svc = alt_svc_header_value(settings.port);
+        app.layer(axum::middleware::from_fn(
+            move |req: Request, next: axum::middleware::Next| {
+                let alt_svc = alt_svc.clone();
+                async move {
+                    let mut res = next.run(req).await;
+                    res.headers_mut().insert(http::header::ALT_SVC, alt_svc);
+                    res
+                }
+            },
+        ))
+    } else {
+        app
+    };
+```
+
+- [ ] **Step 6: Verify both builds and the test suite**
+
+Run: `cargo build --features http3 2>&1 | tail -2 && cargo build 2>&1 | tail -2 && cargo test 2>&1 | tail -5`
+Expected: both builds `Finished`; all tests pass.
+
+- [ ] **Step 7: Run clippy on the http3 feature**
+
+Run: `cargo clippy --features http3 2>&1 | grep -E "warning|error" | head`
+Expected: no new warnings from the H3 code.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/main.rs
+git commit -m "feat(http3): advertise Alt-Svc when H3 is serving; fix h3_addr move; test alt-svc helper"
+```
+
+---
+
+### Task 5: Manual integration verification (acceptance gate)
+
+**Files:** none (runtime verification only).
+
+This task is not automatable in CI (needs a QUIC-capable client and TLS certs). Document the result in the PR.
+
+- [ ] **Step 1: Build with the feature**
+
+Run: `cargo build --features http3`
+Expected: `Finished`.
+
+- [ ] **Step 2: Run with TLS + H3 enabled** (requires `TLS_CERT_PATH`/`TLS_KEY_PATH` and the signing keys per CLAUDE.md)
+
+```bash
+ENABLE_HTTP3=true cargo run --features http3
+```
+
+- [ ] **Step 3: Confirm Alt-Svc is advertised over HTTP/2**
+
+Run: `curl -sI --http2 https://<host>:<port>/health | grep -i alt-svc`
+Expected: `alt-svc: h3=":<port>"; ma=86400`.
+
+- [ ] **Step 4: Confirm a real H3 round-trip** (curl built with HTTP/3 support)
+
+Run: `curl -s --http3 https://<host>:<port>/health`
+Expected: `ok` (routed through the Axum `Router`, not an empty 200 stub).
+
+- [ ] **Step 5: Confirm an authenticated H3 round-trip**
+
+Drive any authenticated route (e.g. an OIDC discovery / a CWT-protected endpoint) over `--http3` and confirm the real JSON body returns — proving the bridge passes headers + body, not the old stub.
+
+---
+
+## Acceptance criteria mapping (from issue #15)
+
+- `cargo check/build --features http3` succeed → Tasks 1–3 (Step verifications).
+- H3 handler routes through the Axum `Router`, bodies included → Task 3.
+- H3 runs alongside HTTP/2 on the same `:443` (TCP+UDP) → unchanged spawn wiring + Task 2.
+- `Alt-Svc` advertises HTTP/3 → Task 4.
+- Real client completes an authenticated H3 round-trip → Task 5.
+- Default build + HTTP/1.1+HTTP/2 unchanged → Task 3 Step 4, Task 4 `advertise_h3` runtime gate.

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,8 @@ use tokio::sync::RwLock;
 use tokio_rustls::TlsAcceptor;
 use tower::Service;
 use tower::ServiceBuilder;
+#[cfg(feature = "http3")]
+use tower::ServiceExt; // Router::oneshot in the HTTP/3 → Axum bridge
 use tower_sessions::cookie::SameSite;
 use tower_sessions::cookie::time::Duration;
 use tower_sessions::{Expiry, MemoryStore, SessionManagerLayer};
@@ -95,10 +97,10 @@ async fn run_h3_server(
 
     // Bind UDP socket
     let socket = std::net::UdpSocket::bind(addr)?;
-    let endpoint = quinn::Endpoint::new_with_abstract_socket(
+    let endpoint = quinn::Endpoint::new(
         quinn::EndpointConfig::default(),
         Some(quinn_server_config),
-        socket.try_into()?,
+        socket,
         Arc::new(quinn::TokioRuntime),
     )?;
 
@@ -129,11 +131,18 @@ async fn handle_h3_connection(
 
     loop {
         match h3_conn.accept().await {
-            Ok(Some((req, stream))) => {
+            // h3 0.0.8: accept() yields a RequestResolver; resolve_request()
+            // awaits the headers and produces the (Request, RequestStream) pair.
+            Ok(Some(resolver)) => {
                 let app = app.clone();
                 tokio::spawn(async move {
-                    if let Err(e) = handle_h3_request(req, stream, app).await {
-                        eprintln!("HTTP/3 request error: {}", e);
+                    match resolver.resolve_request().await {
+                        Ok((req, stream)) => {
+                            if let Err(e) = handle_h3_request(req, stream, app).await {
+                                eprintln!("HTTP/3 request error: {}", e);
+                            }
+                        }
+                        Err(e) => eprintln!("HTTP/3 request resolve error: {}", e),
                     }
                 });
             }
@@ -151,19 +160,48 @@ async fn handle_h3_connection(
 #[cfg(feature = "http3")]
 async fn handle_h3_request(
     req: http::Request<()>,
-    mut stream: h3::server::RequestStream<h3_quinn::BidiStream<h3_quinn::RecvStream>, bytes::Bytes>,
+    mut stream: h3::server::RequestStream<h3_quinn::BidiStream<bytes::Bytes>, bytes::Bytes>,
     app: Router,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    // Convert H3 request to Axum request
+    use bytes::Buf;
+
+    // 1. Collect the H3 request body into an axum Body (bounded — auth/OIDC
+    //    payloads are tiny; refuse anything larger rather than buffering
+    //    unbounded memory from an untrusted peer).
+    const MAX_H3_BODY: usize = 2 * 1024 * 1024; // 2 MiB
+    let mut body_bytes: Vec<u8> = Vec::new();
+    while let Some(mut chunk) = stream.recv_data().await? {
+        let remaining = chunk.remaining();
+        if body_bytes.len() + remaining > MAX_H3_BODY {
+            let resp = http::Response::builder()
+                .status(StatusCode::PAYLOAD_TOO_LARGE)
+                .body(())
+                .unwrap();
+            stream.send_response(resp).await?;
+            stream.finish().await?;
+            return Ok(());
+        }
+        body_bytes.extend_from_slice(chunk.copy_to_bytes(remaining).as_ref());
+    }
+
     let (parts, _) = req.into_parts();
-    let body = axum::body::Body::empty(); // TODO: Handle request body if needed
-    let axum_req = http::Request::from_parts(parts, body);
+    let axum_req = http::Request::from_parts(parts, axum::body::Body::from(body_bytes));
 
-    // Call the router (this is simplified - production would need proper integration)
-    // For now, just return a basic response
-    let response = http::Response::builder().status(200).body(()).unwrap();
+    // 2. Drive the Axum router as a tower::Service (its error type is Infallible).
+    let response = app
+        .oneshot(axum_req)
+        .await
+        .map_err(|e| format!("router error: {e}"))?;
 
-    stream.send_response(response).await?;
+    // 3. Stream status + headers + body back over the H3 stream.
+    let (resp_parts, resp_body) = response.into_parts();
+    let h3_response = http::Response::from_parts(resp_parts, ());
+    stream.send_response(h3_response).await?;
+
+    let body_bytes = axum::body::to_bytes(resp_body, usize::MAX).await?;
+    if !body_bytes.is_empty() {
+        stream.send_data(body_bytes).await?;
+    }
     stream.finish().await?;
 
     Ok(())
@@ -423,6 +461,30 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .layer(Extension(apple_app_site_association))
         .fallback(handler_fallback);
 
+    // Advertise HTTP/3 via Alt-Svc on the TCP (HTTP/1.1 + HTTP/2) responses, but
+    // only when H3 is actually serving: the feature is compiled in, the runtime
+    // toggle is on, and TLS is enabled (H3 is only spawned in the TLS branch).
+    // This is a no-op for the default build, keeping the non-http3 path
+    // byte-for-byte unchanged.
+    let advertise_h3 = cfg!(feature = "http3")
+        && settings.tls_enabled
+        && env::var("ENABLE_HTTP3").unwrap_or_else(|_| "true".to_string()) == "true";
+    let app = if advertise_h3 {
+        let alt_svc = alt_svc_header_value(settings.port);
+        app.layer(axum::middleware::from_fn(
+            move |req: Request, next: axum::middleware::Next| {
+                let alt_svc = alt_svc.clone();
+                async move {
+                    let mut res = next.run(req).await;
+                    res.headers_mut().insert(http::header::ALT_SVC, alt_svc);
+                    res
+                }
+            },
+        ))
+    } else {
+        app
+    };
+
     let addr = format!("{}:{}", settings.bind_address, settings.port);
     println!("Listening on: {} (HTTP/1.1, HTTP/2, HTTP/3)", addr);
 
@@ -437,12 +499,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             let h3_cert_path = settings.tls_cert_path.clone();
             let h3_key_path = settings.tls_key_path.clone();
 
+            let log_addr = h3_addr.clone();
             tokio::spawn(async move {
                 if let Err(e) = run_h3_server(&h3_addr, h3_app, &h3_cert_path, &h3_key_path).await {
                     eprintln!("HTTP/3 server error: {}", e);
                 }
             });
-            println!("HTTP/3 (QUIC) enabled on UDP {}", h3_addr);
+            println!("HTTP/3 (QUIC) enabled on UDP {}", log_addr);
         }
 
         #[cfg(not(feature = "http3"))]
@@ -519,6 +582,13 @@ async fn health_get() -> &'static str {
 
 async fn health_head() -> StatusCode {
     StatusCode::OK
+}
+
+/// Build the `Alt-Svc` header value advertising HTTP/3 availability on `port`.
+/// `ma` (max-age, seconds) is advisory; 86400s = 24h is a conservative default.
+fn alt_svc_header_value(port: u16) -> http::HeaderValue {
+    http::HeaderValue::from_str(&format!("h3=\":{}\"; ma=86400", port))
+        .expect("alt-svc header value is always valid ASCII")
 }
 
 // Fallback handler - properly handle HEAD requests without body
@@ -930,6 +1000,18 @@ mod tests {
     // Helper function to create test app
     fn create_test_app() -> Router {
         Router::new().route("/oauth/:client/:provider", get(handle_oauth_callback))
+    }
+
+    #[test]
+    fn alt_svc_header_advertises_h3_on_port() {
+        assert_eq!(
+            alt_svc_header_value(443).to_str().unwrap(),
+            "h3=\":443\"; ma=86400"
+        );
+        assert_eq!(
+            alt_svc_header_value(8443).to_str().unwrap(),
+            "h3=\":8443\"; ma=86400"
+        );
     }
 
     #[tokio::test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -189,6 +189,12 @@ async fn handle_h3_request(
         body_bytes.extend_from_slice(chunk.copy_to_bytes(remaining).as_ref());
     }
 
+    // A response to HEAD must carry the same headers as the GET-equivalent
+    // (including Content-Length) but no message body. The TCP path gets this for
+    // free from hyper; on H3 we serve the response ourselves, so capture the
+    // method now and suppress the body frame below.
+    let is_head = req.method() == Method::HEAD;
+
     let (parts, _) = req.into_parts();
     let axum_req = http::Request::from_parts(parts, axum::body::Body::from(body_bytes));
 
@@ -203,9 +209,11 @@ async fn handle_h3_request(
     let h3_response = http::Response::from_parts(resp_parts, ());
     stream.send_response(h3_response).await?;
 
-    let body_bytes = axum::body::to_bytes(resp_body, usize::MAX).await?;
-    if !body_bytes.is_empty() {
-        stream.send_data(body_bytes).await?;
+    if !is_head {
+        let body_bytes = axum::body::to_bytes(resp_body, usize::MAX).await?;
+        if !body_bytes.is_empty() {
+            stream.send_data(body_bytes).await?;
+        }
     }
     stream.finish().await?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -195,7 +195,17 @@ async fn handle_h3_request(
     // method now and suppress the body frame below.
     let is_head = req.method() == Method::HEAD;
 
-    let (parts, _) = req.into_parts();
+    // The QUIC stream frames the body, so the bytes we actually buffered are
+    // authoritative. Normalize Content-Length so the router never sees a
+    // client-supplied value that disagrees with the real body length.
+    let (mut parts, _) = req.into_parts();
+    parts.headers.remove(http::header::CONTENT_LENGTH);
+    if !body_bytes.is_empty() {
+        parts.headers.insert(
+            http::header::CONTENT_LENGTH,
+            http::HeaderValue::from(body_bytes.len() as u64),
+        );
+    }
     let axum_req = http::Request::from_parts(parts, axum::body::Body::from(body_bytes));
 
     // 2. Drive the Axum router as a tower::Service (its error type is Infallible).
@@ -204,15 +214,24 @@ async fn handle_h3_request(
         .await
         .map_err(|e| format!("router error: {e}"))?;
 
-    // 3. Stream status + headers + body back over the H3 stream.
-    let (resp_parts, resp_body) = response.into_parts();
-    let h3_response = http::Response::from_parts(resp_parts, ());
-    stream.send_response(h3_response).await?;
+    // 3. Send status + headers, then forward the response body frame by frame
+    //    (no full-body buffering — keeps memory bounded and preserves streaming
+    //    for any future chunked response). A HEAD response carries the headers
+    //    but no body.
+    let (resp_parts, mut resp_body) = response.into_parts();
+    stream
+        .send_response(http::Response::from_parts(resp_parts, ()))
+        .await?;
 
     if !is_head {
-        let body_bytes = axum::body::to_bytes(resp_body, usize::MAX).await?;
-        if !body_bytes.is_empty() {
-            stream.send_data(body_bytes).await?;
+        use http_body_util::BodyExt;
+        while let Some(frame) = resp_body.frame().await {
+            // Forward data frames; trailers (rare on these routes) are skipped.
+            if let Ok(data) = frame?.into_data() {
+                if !data.is_empty() {
+                    stream.send_data(data).await?;
+                }
+            }
         }
     }
     stream.finish().await?;
@@ -474,6 +493,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .layer(Extension(apple_app_site_association))
         .fallback(handler_fallback);
 
+    // The H3 server serves the base router (without the Alt-Svc layer added
+    // below), so HTTP/3 responses don't redundantly advertise h3 to themselves —
+    // Alt-Svc is only meaningful to upgrade a TCP (HTTP/1.1/2) client to H3.
+    #[cfg(feature = "http3")]
+    let h3_app_base = app.clone();
+
     // Advertise HTTP/3 via Alt-Svc on the TCP (HTTP/1.1 + HTTP/2) responses, but
     // only when H3 is actually serving: the feature is compiled in, the runtime
     // toggle is on, and TLS is enabled (H3 is only spawned in the TLS branch).
@@ -508,7 +533,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         #[cfg(feature = "http3")]
         if env::var("ENABLE_HTTP3").unwrap_or_else(|_| "true".to_string()) == "true" {
             let h3_addr = format!("{}:{}", settings.bind_address, settings.port);
-            let h3_app = app.clone();
+            let h3_app = h3_app_base;
             let h3_cert_path = settings.tls_cert_path.clone();
             let h3_key_path = settings.tls_key_path.clone();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,7 +84,13 @@ async fn run_h3_server(
         .with_no_client_auth()
         .with_single_cert(certs, key)?;
 
-    server_config.max_early_data_size = 0xffffffff;
+    // Disable QUIC/TLS 1.3 0-RTT (early data). 0-RTT data is replayable by a
+    // network attacker (RFC 9001 §9.2, RFC 8470), and this service's endpoints
+    // are overwhelmingly non-idempotent (token exchange, registration,
+    // authentication, identity linking) with no per-request replay protection.
+    // The only cost is one extra round trip on session resumption; correctness
+    // and replay safety win for an auth/OIDC server. (0 = disabled per rustls.)
+    server_config.max_early_data_size = 0;
     server_config.alpn_protocols = vec![b"h3".to_vec()];
 
     // Create Quinn server config

--- a/src/main.rs
+++ b/src/main.rs
@@ -148,7 +148,12 @@ async fn handle_h3_connection(
             }
             Ok(None) => break,
             Err(e) => {
-                eprintln!("HTTP/3 accept error: {}", e);
+                // accept() returns Err when the connection ends — a client
+                // disconnecting (graceful close, ApplicationClose, timeout) is
+                // routine and terminal, not an operator-actionable error. Record
+                // it at debug instead of spamming stderr on every closed
+                // connection.
+                debug!("HTTP/3 connection accept loop ended: {}", e);
                 break;
             }
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -218,7 +218,23 @@ async fn handle_h3_request(
     //    (no full-body buffering — keeps memory bounded and preserves streaming
     //    for any future chunked response). A HEAD response carries the headers
     //    but no body.
-    let (resp_parts, mut resp_body) = response.into_parts();
+    let (mut resp_parts, mut resp_body) = response.into_parts();
+
+    // hyper synthesizes Content-Length from the body size at the wire layer on
+    // the TCP path; that layer is bypassed here, so replicate it — advertise
+    // Content-Length when the body length is exactly known and not already set.
+    // This gives H3 clients (including HEAD probes, where the body is suppressed
+    // below) the same Content-Length they would see over HTTP/2. Streaming bodies
+    // of unknown size are left without it, exactly as on the TCP path.
+    if !resp_parts.headers.contains_key(http::header::CONTENT_LENGTH)
+        && let Some(len) = http_body::Body::size_hint(&resp_body).exact()
+        && let Ok(value) = http::HeaderValue::from_str(&len.to_string())
+    {
+        resp_parts
+            .headers
+            .insert(http::header::CONTENT_LENGTH, value);
+    }
+
     stream
         .send_response(http::Response::from_parts(resp_parts, ()))
         .await?;

--- a/tests/h3-smoke-client/Cargo.toml
+++ b/tests/h3-smoke-client/Cargo.toml
@@ -1,0 +1,29 @@
+# Standalone manual HTTP/3 smoke-test client for authnz-rs.
+#
+# This is intentionally an isolated crate (note the empty `[workspace]` table,
+# which stops Cargo from treating it as a member of the parent `authnz-rs`
+# package). It is NOT compiled or run by `cargo test` / `cargo build` in the
+# parent — `tests/*.rs` files are, but `tests/<subdir>/` projects are not.
+#
+# It exists because there is no `curl --http3` on the dev machines, so the
+# HTTP/3 acceptance gate for issue #15 / PR #45 is driven with this client.
+# See README.md for usage.
+[package]
+name = "h3-smoke-client"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+# Empty workspace table: isolate this crate from the parent so `cargo` commands
+# run in the repo root never descend into or build it.
+[workspace]
+
+[dependencies]
+# Pinned to the same HTTP/3 stack the server uses (Cargo.toml `http3` feature).
+tokio = { version = "1", features = ["full"] }
+quinn = "0.11"
+h3 = "0.0.8"
+h3-quinn = "0.0.10"
+rustls = { version = "0.23", features = ["ring"] }
+bytes = "1"
+http = "1"

--- a/tests/h3-smoke-client/README.md
+++ b/tests/h3-smoke-client/README.md
@@ -34,6 +34,10 @@ h3-smoke-client <url> [body] [header]
 - `[header]` — optional extra request header, `"Name: Value"`
   (e.g. `"X-Auth-Token: <cwt>"`).
 
+The request method defaults to `POST` when a body is given, otherwise `GET`.
+Override it with the `H3_METHOD` env var, e.g. `H3_METHOD=HEAD` to confirm a
+HEAD response carries headers (incl. `Content-Length`) but no body.
+
 It prints the response status, headers, and body to stdout.
 
 ## Running the full gate

--- a/tests/h3-smoke-client/README.md
+++ b/tests/h3-smoke-client/README.md
@@ -1,0 +1,85 @@
+# h3-smoke-client
+
+A minimal standalone HTTP/3 (QUIC) client for **manually** exercising the
+`authnz-rs` server's HTTP/3 path (the `http3` Cargo feature). It exists because
+the `curl` shipped on macOS/most dev machines is built without HTTP/3, so there
+is otherwise no easy way to drive a real h3 round-trip against the server.
+
+It is the acceptance-gate tool for [issue #15] / PR #45 (the H3 → Axum bridge).
+
+> ⚠️ This client **does not verify the server certificate** — it accepts any
+> cert so it works with the self-signed certs used in local testing. It is a
+> testing tool, not a general-purpose client.
+
+## Isolation
+
+This is a self-contained crate (its `Cargo.toml` has an empty `[workspace]`
+table). It is **not** built or run by `cargo build` / `cargo test` in the
+repo root, and `tests/<subdir>/` projects are not picked up as integration
+tests (only `tests/*.rs` files are). Build it explicitly:
+
+```bash
+cargo build --manifest-path tests/h3-smoke-client/Cargo.toml
+```
+
+## Usage
+
+```
+h3-smoke-client <url> [body] [header]
+```
+
+- `<url>` — request URL (default `https://127.0.0.1:8443/health`)
+- `[body]` — optional request body. Non-empty ⇒ `POST` with
+  `Content-Type: application/x-www-form-urlencoded`. Empty/omitted ⇒ `GET`.
+- `[header]` — optional extra request header, `"Name: Value"`
+  (e.g. `"X-Auth-Token: <cwt>"`).
+
+It prints the response status, headers, and body to stdout.
+
+## Running the full gate
+
+Bring up the server with HTTP/3 enabled (see the repo `CLAUDE.md` for key
+generation; a self-signed cert on `127.0.0.1` is fine):
+
+```bash
+# keys + self-signed cert (example)
+openssl ecparam -genkey -name prime256v1 -noout -out signkey.pem
+openssl ecparam -genkey -noout -name prime256v1 | openssl pkcs8 -topk8 -nocrypt -out encodekey.pem
+openssl ec -in encodekey.pem -pubout -out decodekey.pem
+openssl req -x509 -newkey ec -pkeyopt ec_paramgen_curve:prime256v1 -nodes \
+  -keyout privkey.pem -out fullchain.pem -days 2 -subj "/CN=localhost" \
+  -addext "subjectAltName=DNS:localhost,IP:127.0.0.1"
+echo '{"applinks":{"apps":[],"details":[]}}' > apple-app-site-association.json
+
+# run the server (http3)
+SIGN_KEY_PATH=signkey.pem ENCODING_KEY_PATH=encodekey.pem DECODING_KEY_PATH=decodekey.pem \
+TLS_CERT_PATH=fullchain.pem TLS_KEY_PATH=privkey.pem \
+BIND_ADDRESS=127.0.0.1 PORT=8443 ENABLE_HTTP3=true OIDC_ISSUER=https://localhost:8443 \
+cargo run --features http3
+```
+
+Then, from another shell:
+
+```bash
+C="cargo run --quiet --manifest-path tests/h3-smoke-client/Cargo.toml --"
+
+# real Axum response over H3 (not the old empty-200 stub)
+$C https://127.0.0.1:8443/health
+# real JSON body streamed over H3
+$C https://127.0.0.1:8443/.well-known/openid-configuration
+# status passthrough
+$C https://127.0.0.1:8443/nonexistent
+# request body reaches the handler (400 unsupported_grant_type vs 422 for empty)
+$C https://127.0.0.1:8443/oauth/token "grant_type=foobar"
+# auth-gated handler executes over H3, custom header carried
+$C "https://127.0.0.1:8443/oauth/authorize?response_type=code&client_id=foo&redirect_uri=https://x/cb&scope=openid&state=s" "" "X-Auth-Token: bad"
+```
+
+To confirm `Alt-Svc` advertisement over HTTP/2 (system curl is fine for this):
+
+```bash
+curl -ksI --http2 https://127.0.0.1:8443/health | grep -i alt-svc
+# alt-svc: h3=":8443"; ma=86400
+```
+
+[issue #15]: https://github.com/arkavo-org/authnz-rs/issues/15

--- a/tests/h3-smoke-client/src/main.rs
+++ b/tests/h3-smoke-client/src/main.rs
@@ -103,16 +103,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         eprintln!("[client] connection closed: {:?}", err);
     };
 
+    // Optional method override via H3_METHOD (e.g. H3_METHOD=HEAD). Defaults to
+    // POST when a body is given, otherwise GET.
+    let method_override = std::env::var("H3_METHOD").ok();
+
     let request = async move {
-        let mut builder = if let Some(ref b) = post_body {
-            http::Request::builder()
-                .method("POST")
-                .uri(&uri)
+        let method = method_override
+            .clone()
+            .unwrap_or_else(|| if post_body.is_some() { "POST" } else { "GET" }.to_string());
+        let mut builder = http::Request::builder().method(method.as_str()).uri(&uri);
+        if let Some(ref b) = post_body {
+            builder = builder
                 .header("content-type", "application/x-www-form-urlencoded")
-                .header("content-length", b.len().to_string())
-        } else {
-            http::Request::builder().uri(&uri)
-        };
+                .header("content-length", b.len().to_string());
+        }
         if let Some(ref h) = extra_header {
             if let Some((name, value)) = h.split_once(':') {
                 builder = builder.header(name.trim(), value.trim());

--- a/tests/h3-smoke-client/src/main.rs
+++ b/tests/h3-smoke-client/src/main.rs
@@ -1,0 +1,159 @@
+//! Minimal HTTP/3 (QUIC) smoke-test client for authnz-rs.
+//!
+//! macOS/dev `curl` is typically built without HTTP/3, so this client drives the
+//! `--features http3` server over a real QUIC/h3 connection to confirm the
+//! H3 -> Axum bridge routes real requests (see issue #15 / PR #45).
+//!
+//! It does NOT verify the server certificate (accepts any cert) — it is a local
+//! testing tool only, intended for self-signed certs on `127.0.0.1`.
+//!
+//! Usage:
+//!   h3-smoke-client <url> [body] [header]
+//!
+//!   <url>     request URL, e.g. https://127.0.0.1:8443/health  (default if omitted)
+//!   [body]    optional request body. Non-empty => POST with
+//!             `Content-Type: application/x-www-form-urlencoded`. Empty/omitted => GET.
+//!   [header]  optional extra request header as "Name: Value", e.g. "X-Auth-Token: <cwt>"
+//!
+//! Examples:
+//!   h3-smoke-client https://127.0.0.1:8443/health
+//!   h3-smoke-client https://127.0.0.1:8443/oauth/token "grant_type=foobar"
+//!   h3-smoke-client https://127.0.0.1:8443/oauth/authorize?... "" "X-Auth-Token: bad"
+//!
+//! Prints the response status and body to stdout; connection diagnostics to stderr.
+
+use std::sync::Arc;
+
+use bytes::Buf;
+
+/// Certificate verifier that accepts everything. Local testing only — never use
+/// this against a server whose identity you need to trust.
+#[derive(Debug)]
+struct NoVerify(Arc<rustls::crypto::CryptoProvider>);
+
+impl rustls::client::danger::ServerCertVerifier for NoVerify {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &rustls::pki_types::CertificateDer<'_>,
+        _intermediates: &[rustls::pki_types::CertificateDer<'_>],
+        _server_name: &rustls::pki_types::ServerName<'_>,
+        _ocsp: &[u8],
+        _now: rustls::pki_types::UnixTime,
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::danger::ServerCertVerified::assertion())
+    }
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &rustls::pki_types::CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &rustls::pki_types::CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        self.0.signature_verification_algorithms.supported_schemes()
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let url = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "https://127.0.0.1:8443/health".to_string());
+    let uri: http::Uri = url.parse()?;
+    let host = uri.host().unwrap_or("127.0.0.1").to_string();
+    let port = uri.port_u16().unwrap_or(443);
+    let addr: std::net::SocketAddr = format!("{}:{}", host, port).parse()?;
+
+    // Non-empty arg 2 => POST that body; arg 3 => extra "Name: Value" header.
+    let post_body = std::env::args().nth(2).filter(|s| !s.is_empty());
+    let extra_header = std::env::args().nth(3);
+
+    let provider = Arc::new(rustls::crypto::ring::default_provider());
+    let mut tls = rustls::ClientConfig::builder_with_provider(provider.clone())
+        .with_safe_default_protocol_versions()?
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(NoVerify(provider)))
+        .with_no_client_auth();
+    tls.alpn_protocols = vec![b"h3".to_vec()];
+
+    let quic_client = quinn::crypto::rustls::QuicClientConfig::try_from(tls)?;
+    let client_config = quinn::ClientConfig::new(Arc::new(quic_client));
+
+    let mut endpoint = quinn::Endpoint::client("0.0.0.0:0".parse()?)?;
+    endpoint.set_default_client_config(client_config);
+
+    eprintln!("[client] connecting to {} (sni={})", addr, host);
+    let conn = endpoint.connect(addr, &host)?.await?;
+    eprintln!("[client] QUIC connected, ALPN h3 negotiated");
+
+    let h3_conn = h3_quinn::Connection::new(conn);
+    let (mut driver, mut send_request) = h3::client::new(h3_conn).await?;
+
+    let drive = async move {
+        let err = std::future::poll_fn(|cx| driver.poll_close(cx)).await;
+        eprintln!("[client] connection closed: {:?}", err);
+    };
+
+    let request = async move {
+        let mut builder = if let Some(ref b) = post_body {
+            http::Request::builder()
+                .method("POST")
+                .uri(&uri)
+                .header("content-type", "application/x-www-form-urlencoded")
+                .header("content-length", b.len().to_string())
+        } else {
+            http::Request::builder().uri(&uri)
+        };
+        if let Some(ref h) = extra_header {
+            if let Some((name, value)) = h.split_once(':') {
+                builder = builder.header(name.trim(), value.trim());
+            }
+        }
+        let req = builder.body(())?;
+
+        let mut stream = send_request.send_request(req).await?;
+        if let Some(ref b) = post_body {
+            stream.send_data(bytes::Bytes::from(b.clone())).await?;
+        }
+        stream.finish().await?;
+
+        let resp = stream.recv_response().await?;
+        println!("STATUS: {}", resp.status());
+        let mut hdrs: Vec<String> = resp
+            .headers()
+            .iter()
+            .map(|(k, v)| format!("{}: {}", k, v.to_str().unwrap_or("<binary>")))
+            .collect();
+        hdrs.sort();
+        println!("HEADERS:\n{}", hdrs.join("\n"));
+
+        let mut body = Vec::new();
+        while let Some(mut chunk) = stream.recv_data().await? {
+            let n = chunk.remaining();
+            body.extend_from_slice(chunk.copy_to_bytes(n).as_ref());
+        }
+        println!(
+            "BODY ({} bytes): {}",
+            body.len(),
+            String::from_utf8_lossy(&body)
+        );
+        Ok::<(), Box<dyn std::error::Error>>(())
+    };
+
+    tokio::select! {
+        _ = drive => {}
+        r = request => { r?; }
+    }
+
+    endpoint.wait_idle().await;
+    Ok(())
+}

--- a/tests/zerortt-probe/Cargo.toml
+++ b/tests/zerortt-probe/Cargo.toml
@@ -1,0 +1,19 @@
+# Standalone manual probe for whether the HTTP/3 server offers TLS 1.3 0-RTT
+# (early data). 0-RTT data is replayable, so it is deliberately disabled on the
+# server (src/main.rs: max_early_data_size = 0); this tool is how that is
+# verified end-to-end.
+#
+# Isolated crate (empty `[workspace]` table) — NOT built or run by the parent
+# `cargo build` / `cargo test`. See README.md.
+[package]
+name = "zerortt-probe"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[workspace]
+
+[dependencies]
+tokio = { version = "1", features = ["full"] }
+quinn = "0.11"
+rustls = { version = "0.23", features = ["ring"] }

--- a/tests/zerortt-probe/README.md
+++ b/tests/zerortt-probe/README.md
@@ -1,0 +1,63 @@
+# zerortt-probe
+
+A standalone manual probe that checks whether the `authnz-rs` HTTP/3 server
+offers **TLS 1.3 0-RTT (early data)**.
+
+0-RTT early data is **replayable** by a network attacker (RFC 9001 §9.2,
+RFC 8470). This service's endpoints are overwhelmingly non-idempotent (token
+exchange, registration, authentication, identity linking) and have no
+per-request replay protection, so 0-RTT is **deliberately disabled** on the
+server:
+
+```rust
+// src/main.rs, run_h3_server()
+server_config.max_early_data_size = 0; // 0 = disabled (rustls)
+```
+
+This tool verifies that decision end-to-end instead of trusting the flag.
+
+> ⚠️ Local testing tool only: it does **not** verify the server certificate.
+
+## Isolation
+
+Self-contained crate (empty `[workspace]` table). It is **not** built or run by
+`cargo build` / `cargo test` in the repo root. Build it explicitly:
+
+```bash
+cargo build --manifest-path tests/zerortt-probe/Cargo.toml
+```
+
+## How it works
+
+1. Connect once (full 1-RTT handshake) so the server issues a TLS session ticket.
+2. Reconnect on the same endpoint and call `quinn::Connecting::into_0rtt()`,
+   which succeeds only when the client holds 0-RTT keys — and it only gets those
+   if the resumed session granted early data (server `max_early_data_size != 0`).
+
+```
+Exit 0  →  RESULT: 0-RTT DISABLED   (expected, safe)
+Exit 1  →  RESULT: 0-RTT AVAILABLE  (server granted/accepted early data)
+```
+
+## Usage
+
+```
+zerortt-probe [addr] [server_name]
+  addr         default 127.0.0.1:8443
+  server_name  SNI / cert name, default localhost
+```
+
+Bring up the server with HTTP/3 enabled (see `tests/h3-smoke-client/README.md`
+for key/cert generation), then:
+
+```bash
+cargo run --manifest-path tests/zerortt-probe/Cargo.toml
+# RESULT: 0-RTT DISABLED — no early-data keys; resumption falls back to 1-RTT.
+```
+
+### Confirming the probe discriminates (A/B)
+
+To prove the probe isn't always reporting "disabled", temporarily set
+`max_early_data_size = 0xffffffff` in `run_h3_server`, rebuild, and re-run — it
+then reports `0-RTT AVAILABLE` / `ZeroRttAccepted = true`. Revert to `0`
+afterwards.

--- a/tests/zerortt-probe/src/main.rs
+++ b/tests/zerortt-probe/src/main.rs
@@ -1,0 +1,123 @@
+//! Manual probe: does the HTTP/3 server offer TLS 1.3 0-RTT (early data)?
+//!
+//! 0-RTT early data is replayable by a network attacker (RFC 9001 §9.2,
+//! RFC 8470), so this service disables it (`src/main.rs`:
+//! `max_early_data_size = 0`). This tool verifies that end-to-end:
+//!
+//! 1. Connect once (full 1-RTT handshake) to obtain a session ticket.
+//! 2. Reconnect on the same endpoint and attempt 0-RTT via
+//!    `quinn::Connecting::into_0rtt`. That returns `Ok` only when the client
+//!    holds 0-RTT keys, which it gets only if the resumed session granted early
+//!    data — i.e. the server's rustls `max_early_data_size` was non-zero.
+//!
+//! Exit code 0 = 0-RTT DISABLED (the expected, safe state); 1 = 0-RTT AVAILABLE.
+//! It does NOT verify the server certificate (local testing tool only).
+//!
+//! Usage: `zerortt-probe [addr] [server_name]`
+//!   addr         default `127.0.0.1:8443`
+//!   server_name  SNI / cert name, default `localhost`
+
+use std::sync::Arc;
+use std::time::Duration;
+
+#[derive(Debug)]
+struct NoVerify(Arc<rustls::crypto::CryptoProvider>);
+
+impl rustls::client::danger::ServerCertVerifier for NoVerify {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &rustls::pki_types::CertificateDer<'_>,
+        _intermediates: &[rustls::pki_types::CertificateDer<'_>],
+        _server_name: &rustls::pki_types::ServerName<'_>,
+        _ocsp: &[u8],
+        _now: rustls::pki_types::UnixTime,
+    ) -> Result<rustls::client::danger::ServerCertVerified, rustls::Error> {
+        Ok(rustls::client::danger::ServerCertVerified::assertion())
+    }
+    fn verify_tls12_signature(
+        &self,
+        _message: &[u8],
+        _cert: &rustls::pki_types::CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+    fn verify_tls13_signature(
+        &self,
+        _message: &[u8],
+        _cert: &rustls::pki_types::CertificateDer<'_>,
+        _dss: &rustls::DigitallySignedStruct,
+    ) -> Result<rustls::client::danger::HandshakeSignatureValid, rustls::Error> {
+        Ok(rustls::client::danger::HandshakeSignatureValid::assertion())
+    }
+    fn supported_verify_schemes(&self) -> Vec<rustls::SignatureScheme> {
+        self.0.signature_verification_algorithms.supported_schemes()
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let addr: std::net::SocketAddr = std::env::args()
+        .nth(1)
+        .unwrap_or_else(|| "127.0.0.1:8443".to_string())
+        .parse()?;
+    let server_name = std::env::args()
+        .nth(2)
+        .unwrap_or_else(|| "localhost".to_string());
+
+    let provider = Arc::new(rustls::crypto::ring::default_provider());
+    let mut tls = rustls::ClientConfig::builder_with_provider(provider.clone())
+        .with_safe_default_protocol_versions()?
+        .dangerous()
+        .with_custom_certificate_verifier(Arc::new(NoVerify(provider)))
+        .with_no_client_auth();
+    tls.alpn_protocols = vec![b"h3".to_vec()];
+    // The client WANTS 0-RTT: it keeps early-data keys whenever the server's
+    // session ticket grants them. (Default resumption store is in-memory.)
+    tls.enable_early_data = true;
+
+    let quic = quinn::crypto::rustls::QuicClientConfig::try_from(tls)?;
+    let client_cfg = quinn::ClientConfig::new(Arc::new(quic));
+    let mut endpoint = quinn::Endpoint::client("0.0.0.0:0".parse()?)?;
+    endpoint.set_default_client_config(client_cfg);
+
+    // --- Connection 1: full handshake, collect a session ticket. ---
+    eprintln!(
+        "[1] connecting to {} (sni={}) for a session ticket...",
+        addr, server_name
+    );
+    let conn1 = endpoint.connect(addr, &server_name)?.await?;
+    eprintln!("[1] handshake complete; waiting for NewSessionTicket...");
+    // Hold the connection open so the server's post-handshake ticket arrives and
+    // is stored in the client's resumption cache.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+    conn1.close(0u32.into(), b"done");
+    tokio::time::sleep(Duration::from_millis(200)).await;
+
+    // --- Connection 2: attempt 0-RTT on resumption. ---
+    eprintln!("[2] reconnecting and attempting 0-RTT (early data)...");
+    let connecting = endpoint.connect(addr, &server_name)?;
+    match connecting.into_0rtt() {
+        Ok((conn, accepted)) => {
+            println!(
+                "RESULT: 0-RTT AVAILABLE — client holds early-data keys (server granted early data)."
+            );
+            let was_accepted = accepted.await;
+            println!(
+                "       ZeroRttAccepted = {} (server {} the 0-RTT data)",
+                was_accepted,
+                if was_accepted { "ACCEPTED" } else { "rejected" }
+            );
+            conn.close(0u32.into(), b"done");
+            endpoint.wait_idle().await;
+            std::process::exit(1);
+        }
+        Err(_connecting) => {
+            println!(
+                "RESULT: 0-RTT DISABLED — no early-data keys; resumption falls back to 1-RTT."
+            );
+            endpoint.wait_idle().await;
+            std::process::exit(0);
+        }
+    }
+}


### PR DESCRIPTION
Closes #15 (pending the manual H3 round-trip acceptance step — see "Remaining acceptance" below).

## What

Makes the feature-gated HTTP/3 (QUIC) server actually compile and route real requests through the existing Axum `Router`, alongside HTTP/2, with `Alt-Svc` advertisement. Both blockers from #15 are resolved.

### Blocker 1 — dependency skew (fixed)
Bumped the optional HTTP/3 dep set so `h3-quinn` builds against the `quinn 0.11.9` that resolves today:

| crate | before | after |
|-------|--------|-------|
| `h3` | `0.0.6` | `0.0.8` |
| `h3-quinn` | `0.0.8` | `0.0.10` |
| `quinn` | `0.11` | `0.11` (unchanged; resolves 0.11.9) |

`h3-quinn 0.0.10` requires `h3 ^0.0.8` + `quinn ^0.11.7`, which collapses the dual-`h3` skew to a single `h3 0.0.8` and clears the private-`StreamId` (`E0616`) error. **Verified:** `cargo tree --features http3` shows one `h3 0.0.8`; `h3-quinn` compiles cleanly against `quinn 0.11.9`.

### Blocker 2 — non-functional stub (fixed)
`handle_h3_request` discarded the body and the `Router`, returning an empty `200` for **every** request. It now:
1. Collects the H3 request body into an `axum::body::Body` (bounded to 2 MiB — auth/OIDC payloads are tiny; oversized bodies get `413` rather than unbounded buffering).
2. Drives the `Router` via `tower::ServiceExt::oneshot`.
3. Streams the real status / headers / body back over the H3 stream.

Also ported `run_h3_server` / `handle_h3_connection` to the 0.0.8 API (`quinn::Endpoint::new` with a std `UdpSocket`; `accept()` → `RequestResolver::resolve_request()`; `RequestStream<BidiStream<Bytes>, Bytes>`).

### Alt-Svc
Advertises `Alt-Svc: h3=":<port>"; ma=86400` from the TCP (HTTP/1.1 + HTTP/2) response path, gated so it is a **no-op** unless `http3` is compiled in, `ENABLE_HTTP3` is on, and TLS is enabled.

### Also
- Fixed a pre-existing `borrow of moved value: h3_addr` in the spawn wiring (previously latent because the feature never compiled).
- Bumped `0.6.0 → 0.7.0` (new feature).

## Testing

- ✅ `cargo build` (default) — unchanged; only the pre-existing `webvh.rs` `dead_code` warning.
- ✅ `cargo build --features http3` — `Finished`, no warnings from H3 code.
- ✅ `cargo test` — 171 + 1 passing, incl. new `alt_svc_header_advertises_h3_on_port`.
- ✅ `cargo clippy --features http3` — no new lints from H3 code (remaining warnings are pre-existing in `authn.rs`/`cwt.rs`/`db.rs`/the key-loader tuple type).

## Remaining acceptance (manual, not CI-automatable)

The final #15 criterion — a real client (`curl --http3`) completing an authenticated round-trip over H3 — needs a QUIC-capable client and TLS certs, so it is a manual gate. Steps are documented in the plan (`docs/superpowers/plans/2026-06-20-http3-quinn-bridge.md`, Task 5). **Draft until that round-trip is confirmed against a deployed instance.**

## Default-build safety

All H3 code stays behind `#[cfg(feature = "http3")]`; the `Alt-Svc` layer is runtime-gated to a no-op. The default build and the HTTP/1.1 + HTTP/2 paths are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
